### PR TITLE
Make scale numbers partially translucent

### DIFF
--- a/public/style_backend.css
+++ b/public/style_backend.css
@@ -138,7 +138,7 @@ h2 sup {
 	font-size: 13px;
 	line-height: 1;
 	position: absolute;
-	background-color: #fff;
+	background-image: linear-gradient(to bottom, #fff 0%, #fff 50%, rgba(255, 255, 255, 0.75) 50%);
 	font-weight: bold;
 	right: .5em;
 	top: -.5em;


### PR DESCRIPTION
Make the backgrounds of the bottom halves of scale numbers 75% opaque,
so that they don't completely obscure the red bars when they overlap
(which seems common), but the top border is still neatly obscured.