### PR TITLE
Use chi router for HTTP tests

### DIFF
--- a/.codecov.yaml
+++ b/.codecov.yaml
@@ -4,5 +4,5 @@ coverage:
   range: 50..90
   round: down
   precision: 2
-status:
-  patch: no
+  status:
+    patch: false

--- a/cmd/goatcounter/main.go
+++ b/cmd/goatcounter/main.go
@@ -105,7 +105,7 @@ func main() {
 	// Set up HTTP handler and servers.
 	zhttp.Serve(&http.Server{Addr: cfg.Listen, Handler: zhttp.HostRoute(map[string]chi.Router{
 		cfg.Domain:          zhttp.RedirectHost("//www." + cfg.Domain),
-		"www." + cfg.Domain: handlers.NewSite(db),
+		"www." + cfg.Domain: handlers.NewWebsite(db),
 		cfg.DomainStatic:    handlers.NewStatic("./public", cfg.Domain, cfg.Prod),
 		"*." + cfg.Domain:   handlers.NewBackend(db),
 	})}, func() {

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module zgo.at/goatcounter
 
-go 1.12
+go 1.13
 
 require (
 	github.com/davecgh/go-spew v1.1.1 // indirect

--- a/handlers/backend.go
+++ b/handlers/backend.go
@@ -28,9 +28,9 @@ import (
 	"zgo.at/goatcounter/cfg"
 )
 
-type Backend struct{}
+type backend struct{}
 
-func (h Backend) Mount(r chi.Router, db *sqlx.DB) {
+func (h backend) Mount(r chi.Router, db *sqlx.DB) {
 	r.Use(
 		middleware.RealIP,
 		zhttp.Unpanic(cfg.Prod),
@@ -105,7 +105,7 @@ var gif = []byte{0x47, 0x49, 0x46, 0x38, 0x39, 0x61, 0x1, 0x0, 0x1, 0x0, 0x80,
 	0x1, 0x0, 0x2c, 0x0, 0x0, 0x0, 0x0, 0x1, 0x0, 0x1, 0x0, 0x0, 0x2, 0x2, 0x4c,
 	0x1, 0x0, 0x3b}
 
-func (h Backend) count(w http.ResponseWriter, r *http.Request) error {
+func (h backend) count(w http.ResponseWriter, r *http.Request) error {
 	w.Header().Set("Cache-Control", "no-store,no-cache")
 
 	// Don't track pages fetched with the browser's prefetch algorithm.
@@ -136,7 +136,7 @@ func (h Backend) count(w http.ResponseWriter, r *http.Request) error {
 
 const day = 24 * time.Hour
 
-func (h Backend) index(w http.ResponseWriter, r *http.Request) error {
+func (h backend) index(w http.ResponseWriter, r *http.Request) error {
 	// Cache much more aggressively for public displays. Don't care so much if
 	// it's outdated by an hour.
 	if goatcounter.MustGetSite(r.Context()).Settings.Public &&
@@ -237,7 +237,7 @@ func (h Backend) index(w http.ResponseWriter, r *http.Request) error {
 	return x
 }
 
-func (h Backend) admin(w http.ResponseWriter, r *http.Request) error {
+func (h backend) admin(w http.ResponseWriter, r *http.Request) error {
 	if goatcounter.MustGetSite(r.Context()).ID != 1 {
 		return guru.New(403, "yeah nah")
 	}
@@ -254,7 +254,7 @@ func (h Backend) admin(w http.ResponseWriter, r *http.Request) error {
 	}{newGlobals(w, r), a})
 }
 
-func (h Backend) refs(w http.ResponseWriter, r *http.Request) error {
+func (h backend) refs(w http.ResponseWriter, r *http.Request) error {
 	start, err := time.Parse("2006-01-02", r.URL.Query().Get("period-start"))
 	if err != nil {
 		return err
@@ -291,7 +291,7 @@ func (h Backend) refs(w http.ResponseWriter, r *http.Request) error {
 	})
 }
 
-func (h Backend) browsers(w http.ResponseWriter, r *http.Request) error {
+func (h backend) browsers(w http.ResponseWriter, r *http.Request) error {
 	start, err := time.Parse("2006-01-02", r.URL.Query().Get("period-start"))
 	if err != nil {
 		return err
@@ -315,7 +315,7 @@ func (h Backend) browsers(w http.ResponseWriter, r *http.Request) error {
 	})
 }
 
-func (h Backend) pages(w http.ResponseWriter, r *http.Request) error {
+func (h backend) pages(w http.ResponseWriter, r *http.Request) error {
 	start, err := time.Parse("2006-01-02", r.URL.Query().Get("period-start"))
 	if err != nil {
 		return err
@@ -359,7 +359,7 @@ func (h Backend) pages(w http.ResponseWriter, r *http.Request) error {
 	})
 }
 
-func (h Backend) settings(w http.ResponseWriter, r *http.Request) error {
+func (h backend) settings(w http.ResponseWriter, r *http.Request) error {
 	var sites goatcounter.Sites
 	err := sites.ListSubs(r.Context())
 	if err != nil {
@@ -372,7 +372,7 @@ func (h Backend) settings(w http.ResponseWriter, r *http.Request) error {
 	}{newGlobals(w, r), sites})
 }
 
-func (h Backend) save(w http.ResponseWriter, r *http.Request) error {
+func (h backend) save(w http.ResponseWriter, r *http.Request) error {
 	args := struct {
 		Name     string                   `json:"name"`
 		Settings goatcounter.SiteSettings `json:"settings"`
@@ -396,7 +396,7 @@ func (h Backend) save(w http.ResponseWriter, r *http.Request) error {
 	return zhttp.SeeOther(w, "/settings")
 }
 
-func (h Backend) export(w http.ResponseWriter, r *http.Request) error {
+func (h backend) export(w http.ResponseWriter, r *http.Request) error {
 	file := strings.ToLower(chi.URLParam(r, "file"))
 
 	w.Header().Set("Content-Type", "text/csv")
@@ -449,7 +449,7 @@ func (h Backend) export(w http.ResponseWriter, r *http.Request) error {
 	return c.Error()
 }
 
-func (h Backend) removeConfirm(w http.ResponseWriter, r *http.Request) error {
+func (h backend) removeConfirm(w http.ResponseWriter, r *http.Request) error {
 	v := validate.New()
 	id := v.Integer("id", chi.URLParam(r, "id"))
 	if v.HasErrors() {
@@ -468,7 +468,7 @@ func (h Backend) removeConfirm(w http.ResponseWriter, r *http.Request) error {
 	}{newGlobals(w, r), s})
 }
 
-func (h Backend) remove(w http.ResponseWriter, r *http.Request) error {
+func (h backend) remove(w http.ResponseWriter, r *http.Request) error {
 	v := validate.New()
 	id := v.Integer("id", chi.URLParam(r, "id"))
 	if v.HasErrors() {
@@ -490,7 +490,7 @@ func (h Backend) remove(w http.ResponseWriter, r *http.Request) error {
 	return zhttp.SeeOther(w, "/settings")
 }
 
-func (h Backend) add(w http.ResponseWriter, r *http.Request) error {
+func (h backend) add(w http.ResponseWriter, r *http.Request) error {
 	args := struct {
 		Name string `json:"name"`
 		Code string `json:"code"`

--- a/handlers/handlers.go
+++ b/handlers/handlers.go
@@ -44,14 +44,14 @@ func newGlobals(w http.ResponseWriter, r *http.Request) Globals {
 	return g
 }
 
-func NewSite(db *sqlx.DB) chi.Router {
+func NewWebsite(db *sqlx.DB) chi.Router {
 	if !cfg.Prod {
 		packTpl = nil
 	}
 	zhttp.InitTpl(packTpl)
 
 	r := chi.NewRouter()
-	Website{}.Mount(r, db)
+	website{}.Mount(r, db)
 	return r
 }
 
@@ -72,6 +72,6 @@ func NewStatic(dir, domain string, prod bool) chi.Router {
 
 func NewBackend(db *sqlx.DB) chi.Router {
 	r := chi.NewRouter()
-	Backend{}.Mount(r, db)
+	backend{}.Mount(r, db)
 	return r
 }

--- a/handlers/website.go
+++ b/handlers/website.go
@@ -24,9 +24,9 @@ import (
 	"zgo.at/goatcounter/cfg"
 )
 
-type Website struct{}
+type website struct{}
 
-func (h Website) Mount(r *chi.Mux, db *sqlx.DB) {
+func (h website) Mount(r *chi.Mux, db *sqlx.DB) {
 	r.Use(
 		middleware.RealIP,
 		zhttp.Unpanic(cfg.Prod),
@@ -44,7 +44,7 @@ func (h Website) Mount(r *chi.Mux, db *sqlx.DB) {
 	user{}.mount(r)
 }
 
-func (h Website) tpl(w http.ResponseWriter, r *http.Request) error {
+func (h website) tpl(w http.ResponseWriter, r *http.Request) error {
 	t := r.URL.Path[1:]
 	if t == "" {
 		t = "home"
@@ -55,7 +55,7 @@ func (h Website) tpl(w http.ResponseWriter, r *http.Request) error {
 	}{newGlobals(w, r), t})
 }
 
-func (h Website) status() func(w http.ResponseWriter, r *http.Request) error {
+func (h website) status() func(w http.ResponseWriter, r *http.Request) error {
 	started := time.Now()
 	return func(w http.ResponseWriter, r *http.Request) error {
 		return zhttp.JSON(w, map[string]string{
@@ -65,7 +65,7 @@ func (h Website) status() func(w http.ResponseWriter, r *http.Request) error {
 	}
 }
 
-func (h Website) signup(w http.ResponseWriter, r *http.Request) error {
+func (h website) signup(w http.ResponseWriter, r *http.Request) error {
 	plan, planName, err := getPlan(r)
 	if err != nil {
 		return err
@@ -84,22 +84,24 @@ func (h Website) signup(w http.ResponseWriter, r *http.Request) error {
 		goatcounter.User{}, map[string][]string{}, ""})
 }
 
-func (h Website) doSignup(w http.ResponseWriter, r *http.Request) error {
+type signupArgs struct {
+	Name       string `json:"site_name"`
+	Code       string `json:"site_code"`
+	Email      string `json:"user_email"`
+	UserName   string `json:"user_name"`
+	TuringTest string `json:"turing_test"`
+	//Card   string `json:"card"`
+	//Exp    string `json:"exp"`
+	//CVC    string `json:"cvc"`
+}
+
+func (h website) doSignup(w http.ResponseWriter, r *http.Request) error {
 	plan, planName, err := getPlan(r)
 	if err != nil {
 		return err
 	}
 
-	args := struct {
-		Name       string `json:"site_name"`
-		Code       string `json:"site_code"`
-		Email      string `json:"user_email"`
-		UserName   string `json:"user_name"`
-		TuringTest string `json:"turing_test"`
-		//Card   string `json:"card"`
-		//Exp    string `json:"exp"`
-		//CVC    string `json:"cvc"`
-	}{}
+	var args signupArgs
 	_, err = zhttp.Decode(r, &args)
 	if err != nil {
 		return err

--- a/handlers/website_test.go
+++ b/handlers/website_test.go
@@ -1,0 +1,96 @@
+// Copyright © 2019 Martin Tournoij <martin@arp242.net>
+// This file is part of GoatCounter and published under the terms of the AGPLv3,
+// which can be found in the LICENSE file or at gnu.org/licenses/agpl.html
+
+package handlers
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestWebsiteTpl(t *testing.T) {
+	tests := []handlerTest{
+		{
+			name:     "index",
+			router:   NewWebsite,
+			path:     "/",
+			wantCode: 200,
+			wantBody: "doesn’t track users;",
+		},
+		{
+			name:     "help",
+			router:   NewWebsite,
+			path:     "/help",
+			wantCode: 200,
+			wantBody: "I don’t see my pageviews?",
+		},
+		{
+			name:     "privacy",
+			router:   NewWebsite,
+			path:     "/privacy",
+			wantCode: 200,
+			wantBody: "GoatCounter does not collect data which can be used to identify",
+		},
+		{
+			name:     "terms",
+			router:   NewWebsite,
+			path:     "/terms",
+			wantCode: 200,
+			wantBody: "The “services” are any software, application, product, or service",
+		},
+
+		{
+			name:     "status",
+			router:   NewWebsite,
+			path:     "/status",
+			wantCode: 200,
+			wantBody: "uptime",
+		},
+
+		{
+			name:     "signup",
+			router:   NewWebsite,
+			path:     "/signup/personal",
+			wantCode: 200,
+			wantBody: `<label for="name">Site name</label>`,
+		},
+	}
+
+	for _, tt := range tests {
+		runTest(t, tt, nil)
+	}
+}
+
+func TestWebsiteSignup(t *testing.T) {
+	tests := []handlerTest{
+		{
+			name:         "basic",
+			method:       "POST",
+			router:       NewWebsite,
+			path:         "/signup/personal",
+			body:         signupArgs{Name: "Example", Code: "example", Email: "m@example.com", UserName: "Example user", TuringTest: "9"},
+			wantCode:     303,
+			wantFormCode: 303,
+		},
+
+		{
+			name:         "no-code",
+			method:       "POST",
+			router:       NewWebsite,
+			path:         "/signup/personal",
+			body:         signupArgs{Name: "Example", Email: "m@example.com", UserName: "Example user", TuringTest: "9"},
+			wantCode:     200,
+			wantBody:     "", // TODO: should return JSON
+			wantFormCode: 200,
+			wantFormBody: "Error: must be set, must be longer than 1 characters",
+		},
+	}
+
+	for _, tt := range tests {
+		runTest(t, tt, func(t *testing.T, rr *httptest.ResponseRecorder, r *http.Request) {
+			// TODO: test state
+		})
+	}
+}


### PR DESCRIPTION
Otherwise the chi context isn't added, and we run in to problems with
chi.URLParam() etc. This is also better because it adds all the
middleware, so that'll get tested too.