### PR TITLE
Re-use LoginKey

### DIFF
--- a/handlers/http_test.go
+++ b/handlers/http_test.go
@@ -19,6 +19,7 @@ import (
 	"github.com/jmoiron/sqlx"
 	"github.com/teamwork/test"
 	"github.com/teamwork/utils/jsonutil"
+	"zgo.at/goatcounter/smail"
 	"zgo.at/zhttp"
 	"zgo.at/zhttp/ctxkey"
 	"zgo.at/zlog"
@@ -44,6 +45,7 @@ func init() {
 	zhttp.TplPath = "../tpl"
 	zhttp.InitTpl(nil)
 	zlog.Config.Outputs = []zlog.OutputFunc{} // Don't care about logs; don't spam.
+	smail.Print = false
 }
 
 func runTest(
@@ -133,9 +135,17 @@ func login(t *testing.T, rr *httptest.ResponseRecorder, r *http.Request) {
 	}
 
 	// Login user
+	err = u.RequestLogin(r.Context())
+	if err != nil {
+		t.Fatal(err)
+	}
 	err = u.Login(r.Context())
 	if err != nil {
 		t.Fatal(err)
+	}
+
+	if u.LoginKey == nil {
+		t.Fatal("u.LoginKey is nil? Should never happen!")
 	}
 
 	r.Header.Set("Cookie", "key="+*u.LoginKey)

--- a/smail/smail.go
+++ b/smail/smail.go
@@ -29,11 +29,14 @@ import (
 
 var reNL = regexp.MustCompile(`(\r\n){2,}`)
 
+// Print emails to stdout if cfg.SMTP if empty.
+var Print = true
+
 // Send an email.
 func Send(subject string, from mail.Address, to []mail.Address, body string) error {
 	msg := Format(subject, from, to, body)
 
-	if cfg.SMTP == "" {
+	if cfg.SMTP == "" && Print {
 		l := strings.Repeat("═", 50)
 		fmt.Println("╔═══ EMAIL " + l + "\n║ " +
 			strings.Replace(strings.TrimSpace(string(msg)), "\r\n", "\r\n║ ", -1) +


### PR DESCRIPTION
I realized we can just re-use the LoginKey instead of creating a more
complex 1:n mapping. The only downside is that people have the login key
in their mailboxes. It's okay for now.

Alternative to #41; fixes #1