### PR TITLE
Don't prefill blank days in hit_stats

### DIFF
--- a/cron/cron.go
+++ b/cron/cron.go
@@ -92,11 +92,6 @@ func persistAndStat(ctx context.Context) error {
 	}
 	l = l.Since("memstore")
 
-	err = fillBlanksForToday(ctx)
-	if err != nil {
-		return errors.Wrapf(err, "fillBlanks")
-	}
-
 	grouped := make(map[int64][]goatcounter.Hit)
 	for _, h := range hits {
 		grouped[h.Site] = append(grouped[h.Site], h)

--- a/db/migrate/pgsql/2019-12-31-1-blank-days.sql
+++ b/db/migrate/pgsql/2019-12-31-1-blank-days.sql
@@ -1,0 +1,4 @@
+begin;
+	delete from hit_stats where stats='[0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0]';
+	insert into version values ('2019-12-31-1-blank-days');
+commit;

--- a/db/migrate/sqlite/2019-12-31-1-blank-days.sql
+++ b/db/migrate/sqlite/2019-12-31-1-blank-days.sql
@@ -1,0 +1,4 @@
+begin;
+	delete from hit_stats where stats='[0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0]';
+	insert into version values ('2019-12-31-1-blank-days');
+commit;

--- a/init.go
+++ b/init.go
@@ -52,7 +52,7 @@ func init() {
 	}
 
 	// Implemented as function for performance.
-	zhttp.FuncMap["bar_chart"] = func(stats []HitStat, max int) template.HTML {
+	zhttp.FuncMap["bar_chart"] = func(stats []Stat, max int) template.HTML {
 		var b strings.Builder
 		now := time.Now().UTC()
 		today := now.Format("2006-01-02")

--- a/memstore.go
+++ b/memstore.go
@@ -52,14 +52,14 @@ func (m *ms) Persist(ctx context.Context) ([]Hit, error) {
 			"ref_scheme", "browser", "size", "location", "created_at", "count_ref"})
 	for i, h := range hits {
 		var err error
-		h.refURL, err = url.Parse(h.Ref)
+		h.RefURL, err = url.Parse(h.Ref)
 		if err != nil {
 			zlog.Field("ref", h.Ref).Errorf("could not parse ref: %s", err)
 			continue
 		}
 
 		// Ignore spammers.
-		if _, ok := blacklist[h.refURL.Host]; ok {
+		if _, ok := blacklist[h.RefURL.Host]; ok {
 			continue
 		}
 

--- a/pack/pack.go
+++ b/pack/pack.go
@@ -408,6 +408,11 @@ commit;
 	insert into version values ('2019-12-20-1-dailystat');
 commit;
 `),
+	"db/migrate/pgsql/2019-12-31-1-blank-days.sql": []byte(`begin;
+	delete from hit_stats where stats='[0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0]';
+	insert into version values ('2019-12-31-1-blank-days');
+commit;
+`),
 }
 
 var MigrationsSQLite = map[string][]byte{
@@ -877,6 +882,11 @@ commit;
 		add column total integer not null default 0;
 
 	insert into version values ('2019-12-20-1-dailystat');
+commit;
+`),
+	"db/migrate/sqlite/2019-12-31-1-blank-days.sql": []byte(`begin;
+	delete from hit_stats where stats='[0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0]';
+	insert into version values ('2019-12-31-1-blank-days');
 commit;
 `),
 }

--- a/pack/pack.go
+++ b/pack/pack.go
@@ -1313,8 +1313,8 @@ h1 a:after, h2 a:after, h3 a:after, h4 a:after, h5 a:after, h6 a:after {
 }
 `),
 	"public/count.js": []byte(`// Copyright © 2019 Martin Tournoij <martin@arp242.net>
-// This file is part of GoatCounter and published under the terms of the AGPLv3,
-// which can be found in the LICENSE file or at gnu.org/licenses/agpl.html
+// This file is part of GoatCounter and published under the terms of the EUPL
+// v1.2, which can be found in the LICENSE file or at http://eupl12.zgo.at
 
 // See /bin/proxy on how to test this locally.
 (function() { 
@@ -1424,8 +1424,8 @@ h1 a:after, h2 a:after, h3 a:after, h4 a:after, h5 a:after, h6 a:after {
 })();
 `),
 	"public/count.min.js": []byte(`// Copyright © 2019 Martin Tournoij <martin@arp242.net>
-// This file is part of GoatCounter and published under the terms of the AGPLv3,
-// which can be found in the LICENSE file or at gnu.org/licenses/agpl.html
+// This file is part of GoatCounter and published under the terms of the EUPL
+// v1.2, which can be found in the LICENSE file or at eupl12.zgo.at
 
 // See /bin/proxy on how to test this locally.
 (function() { 
@@ -10144,8 +10144,8 @@ return jQuery;
 		return s
 	}(),
 	"public/script.js": []byte(`// Copyright © 2019 Martin Tournoij <martin@arp242.net>
-// This file is part of GoatCounter and published under the terms of the AGPLv3,
-// which can be found in the LICENSE file or at gnu.org/licenses/agpl.html
+// This file is part of GoatCounter and published under the terms of the EUPL
+// v1.2, which can be found in the LICENSE file or at http://eupl12.zgo.at
 
 (function() {
 	var init = function() {
@@ -10198,8 +10198,8 @@ return jQuery;
 })();
 `),
 	"public/script_backend.js": []byte(`// Copyright © 2019 Martin Tournoij <martin@arp242.net>
-// This file is part of GoatCounter and published under the terms of the AGPLv3,
-// which can be found in the LICENSE file or at gnu.org/licenses/agpl.html
+// This file is part of GoatCounter and published under the terms of the EUPL
+// v1.2, which can be found in the LICENSE file or at http://eupl12.zgo.at
 
 (function() {
 	'use strict';
@@ -10732,8 +10732,8 @@ return jQuery;
 })();
 `),
 	"public/style.css": []byte(`/* Copyright © 2019 Martin Tournoij <martin@arp242.net>
-   This file is part of GoatCounter and published under the terms of the AGPLv3,
-   which can be found in the LICENSE file or at gnu.org/licenses/agpl.html */
+   This file is part of GoatCounter and published under the terms of the EUPL
+   v1.2, which can be found in the LICENSE file or at http://eupl12.zgo.at */
 
 .page, .center { max-width: 60em; }
 hr             { margin: 1em 0; }
@@ -10888,8 +10888,8 @@ dt { font-weight: bold; margin-top: 1em; }
 
 `),
 	"public/style_backend.css": []byte(`/* Copyright © 2019 Martin Tournoij <martin@arp242.net>
-   This file is part of GoatCounter and published under the terms of the AGPLv3,
-   which can be found in the LICENSE file or at gnu.org/licenses/agpl.html */
+   This file is part of GoatCounter and published under the terms of the EUPL
+   v1.2, which can be found in the LICENSE file or at http://eupl12.zgo.at */
 
 .page    { padding: 1em; }
 footer   { padding: 1em; text-align: center; background-color: #f6f3da; box-shadow: 0 0 4px #cdc8a4;


### PR DESCRIPTION
Right now every day for every path *must* have an entry since the site
start, even if there are no hits that day.

This is actually a lot of data, currently 640k rows/101M:

	goatcounter=# vacuum full;
	VACUUM

	goatcounter=> select count(*) from hit_stats;
	count
	--------
	637240

	goatcounter=# \d+
	Schema |      Name      |   Type   | Owner  |    Size    | Description
	public | hit_stats      | table    | martin | 101 MB     |

Deleting the empty ones reduces this to 40k/4M:

	goatcounter=# delete from hit_stats where stats='[0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0]';
	DELETE 604659

	goatcounter=# vacuum full;
	VACUUM

	goatcounter=# \d+
							List of relations
	Schema |      Name      |   Type   | Owner  |    Size    | Description
	--------+----------------+----------+--------+------------+-------------
	public | hit_stats      | table    | martin | 3992 kB    |

Doing this at runtime is faster than I would have expected, for the last 6
months on arp242.net it *was*

	HitStats.List   293ms  select hits
	HitStats.List    83ms  select hits_stats
	HitStats.List   111ms  reorder data
	HitStats.List   122ms  get total

And is now:

	HitStats.List   137ms  select hits
	HitStats.List    24ms  select hits_stats
	HitStats.List    74ms  reorder data
	HitStats.List     3ms  fill blanks
	HitStats.List    88ms  get total

Only 3ms to fill in the blank data, but we save 249ms in doing everything else!