### PR TITLE
Filter pages

### DIFF
--- a/cron/hit_stat_test.go
+++ b/cron/hit_stat_test.go
@@ -35,7 +35,7 @@ func TestHitStats(t *testing.T) {
 	}
 
 	var stats goatcounter.HitStats
-	total, display, more, err := stats.List(ctx, now, now, nil)
+	total, display, more, err := stats.List(ctx, now, now, "", nil)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/handlers/backend.go
+++ b/handlers/backend.go
@@ -293,21 +293,21 @@ func (h backend) index(w http.ResponseWriter, r *http.Request) error {
 	l = l.Since("pages.List")
 
 	var browsers goatcounter.Stats
-	totalBrowsers, totalMobile, err := browsers.ListBrowsers(r.Context(), start, end, filter)
+	totalBrowsers, totalMobile, err := browsers.ListBrowsers(r.Context(), start, end)
 	if err != nil {
 		return err
 	}
 	l = l.Since("browsers.List")
 
 	var sizeStat goatcounter.Stats
-	err = sizeStat.ListSizes(r.Context(), start, end, filter)
+	totalSize, err := sizeStat.ListSizes(r.Context(), start, end)
 	if err != nil {
 		return err
 	}
 	l = l.Since("sizeStat.ListSizes")
 
 	var locStat goatcounter.Stats
-	totalLoc, err := locStat.ListLocations(r.Context(), start, end, filter)
+	totalLoc, err := locStat.ListLocations(r.Context(), start, end)
 	if err != nil {
 		return err
 	}
@@ -348,12 +348,14 @@ func (h backend) index(w http.ResponseWriter, r *http.Request) error {
 		TotalMobile       string
 		SubSites          []string
 		SizeStat          goatcounter.Stats
+		TotalSize         int
 		LocationStat      goatcounter.Stats
+		TotalLocation     int
 		ShowMoreLocations bool
 	}{newGlobals(w, r), sr, r.URL.Query().Get("hl-period"), start, end, filter,
 		pages, refs, moreRefs, total, totalDisplay, browsers, totalBrowsers,
 		fmt.Sprintf("%.1f", float32(totalMobile)/float32(totalBrowsers)*100),
-		subs, sizeStat, locStat, showMoreLoc})
+		subs, sizeStat, totalSize, locStat, totalLoc, showMoreLoc})
 	l = l.Since("zhttp.Template")
 	l.FieldsSince().Print("")
 	return x
@@ -522,7 +524,7 @@ func (h backend) locations(w http.ResponseWriter, r *http.Request) error {
 	}
 
 	var locStat goatcounter.Stats
-	total, err := locStat.ListLocations(r.Context(), start, end, r.URL.Query().Get("filter"))
+	total, err := locStat.ListLocations(r.Context(), start, end)
 	if err != nil {
 		return err
 	}

--- a/handlers/backend.go
+++ b/handlers/backend.go
@@ -548,7 +548,7 @@ func (h backend) pages(w http.ResponseWriter, r *http.Request) error {
 	}
 
 	var pages goatcounter.HitStats
-	_, totalDisplay, more, err := pages.List(r.Context(), start, end,
+	totalHits, totalDisplay, more, err := pages.List(r.Context(), start, end,
 		r.URL.Query().Get("filter"), strings.Split(r.URL.Query().Get("exclude"), ","))
 	if err != nil {
 		return err
@@ -575,6 +575,7 @@ func (h backend) pages(w http.ResponseWriter, r *http.Request) error {
 	return zhttp.JSON(w, map[string]interface{}{
 		"rows":          string(tpl),
 		"paths":         paths,
+		"total_hits":    totalHits,
 		"total_display": totalDisplay,
 		"more":          more,
 	})

--- a/handlers/backend.go
+++ b/handlers/backend.go
@@ -282,7 +282,6 @@ func (h backend) index(w http.ResponseWriter, r *http.Request) error {
 	}
 
 	filter := r.URL.Query().Get("filter")
-
 	l := zlog.Module("backend").Field("site", site.ID)
 
 	var pages goatcounter.HitStats

--- a/handlers/backend_test.go
+++ b/handlers/backend_test.go
@@ -147,7 +147,7 @@ func TestBackendIndex(t *testing.T) {
 			// TODO: why 0 displayed?
 			// <h2>Pages <sup>(total 1 hits, <span class="total-display">0</span> displayed)</sup></h2>
 			//wantBody: "<h2>Pages <sup>(total 1 hits)</sup></h2>",
-			wantBody: "<h2>Pages <sup>(total 1 hits",
+			wantBody: "<sup>(total 1 hits",
 		},
 	}
 

--- a/handlers/backend_test.go
+++ b/handlers/backend_test.go
@@ -147,7 +147,7 @@ func TestBackendIndex(t *testing.T) {
 			// TODO: why 0 displayed?
 			// <h2>Pages <sup>(total 1 hits, <span class="total-display">0</span> displayed)</sup></h2>
 			//wantBody: "<h2>Pages <sup>(total 1 hits)</sup></h2>",
-			wantBody: "<sup>(total 1 hits",
+			wantBody: `<span class="total-hits">1</span>`,
 		},
 	}
 

--- a/hit.go
+++ b/hit.go
@@ -349,9 +349,6 @@ func (h *HitStats) List(ctx context.Context, start, end time.Time, filter string
 	}
 	l = l.Since("select hits")
 
-	// "" → []string{"/tmux.html", "/goatcounter-1.0.html", "/license.html", "//yaml-config.html", "/dnt.html"}
-	fmt.Printf("%#v → %#v\n", filter, exclude)
-
 	if more {
 		if len(*h) == limit {
 			x := *h

--- a/hit.go
+++ b/hit.go
@@ -349,21 +349,10 @@ func (h *HitStats) List(ctx context.Context, start, end time.Time, filter string
 	}
 	l = l.Since("select hits")
 
-	// TODO: not always correct
-	// TODO: breaks after 2 pages?
-	// More 3 3 []
-	// &[{2380 0 /tmux.html  <nil> []} {230 0 /the-art-of-unix-programming  <nil> []} {95 0 /taoup.html  <nil> []}]
-	//    13:01:07 backend: INFO:  {browsers.List="1ms" locStat.List="1ms" pages.List="85ms" site=1 sizeStat.ListSizes="26ms" zhttp.Template="2ms"}
-	// 13:01:07  200 GET   118ms  arp242.goatcounter.localhost:8081/?filter=x
-	// More 3 3 [/tmux.html /the-art-of-unix-programming ]
-	// &[{95 0 /taoup.html  <nil> []} {70 0 /read-stdin.html  <nil> []} {57 0 /anti-vax.html  <nil> []}]
-	// 13:01:11  200 GET    78ms  arp242.goatcounter.localhost:8081/pages?period-start=2020-01-10&period-end=2020-01-17&filter=x&exclude=%2ftmux.html,%2fthe-art-of-unix-programming,
-	// More 0 3 [/tmux.html /the-art-of-unix-programming /taoup.html /read-stdin.html]
-	// &[]
-	// 13:01:12  200 GET    88ms  arp242.goatcounter.localhost:8081/pages?period-start=2020-01-10&period-end=2020-01-17&filter=false&exclude=%2Ftmux.html%2C%2Fthe-art-of-unix-programming%2C%2Ftaoup.html%2C%2Fread-stdin.html
+	// "" → []string{"/tmux.html", "/goatcounter-1.0.html", "/license.html", "//yaml-config.html", "/dnt.html"}
+	fmt.Printf("%#v → %#v\n", filter, exclude)
+
 	if more {
-		fmt.Println("More", len(*h), limit, exclude)
-		fmt.Println(h)
 		if len(*h) == limit {
 			x := *h
 			x = x[:len(x)-1]

--- a/hit.go
+++ b/hit.go
@@ -305,7 +305,7 @@ func (h *HitStats) List(ctx context.Context, start, end time.Time, filter string
 		limit = 20
 	}
 	more := false
-	if len(exclude) > 0 {
+	if len(exclude) > 0 || filter != "" {
 		// Get one page more so we can detect if there are more pages after
 		// this.
 		more = true
@@ -349,7 +349,21 @@ func (h *HitStats) List(ctx context.Context, start, end time.Time, filter string
 	}
 	l = l.Since("select hits")
 
+	// TODO: not always correct
+	// TODO: breaks after 2 pages?
+	// More 3 3 []
+	// &[{2380 0 /tmux.html  <nil> []} {230 0 /the-art-of-unix-programming  <nil> []} {95 0 /taoup.html  <nil> []}]
+	//    13:01:07 backend: INFO:  {browsers.List="1ms" locStat.List="1ms" pages.List="85ms" site=1 sizeStat.ListSizes="26ms" zhttp.Template="2ms"}
+	// 13:01:07  200 GET   118ms  arp242.goatcounter.localhost:8081/?filter=x
+	// More 3 3 [/tmux.html /the-art-of-unix-programming ]
+	// &[{95 0 /taoup.html  <nil> []} {70 0 /read-stdin.html  <nil> []} {57 0 /anti-vax.html  <nil> []}]
+	// 13:01:11  200 GET    78ms  arp242.goatcounter.localhost:8081/pages?period-start=2020-01-10&period-end=2020-01-17&filter=x&exclude=%2ftmux.html,%2fthe-art-of-unix-programming,
+	// More 0 3 [/tmux.html /the-art-of-unix-programming /taoup.html /read-stdin.html]
+	// &[]
+	// 13:01:12  200 GET    88ms  arp242.goatcounter.localhost:8081/pages?period-start=2020-01-10&period-end=2020-01-17&filter=false&exclude=%2Ftmux.html%2C%2Fthe-art-of-unix-programming%2C%2Ftaoup.html%2C%2Fread-stdin.html
 	if more {
+		fmt.Println("More", len(*h), limit, exclude)
+		fmt.Println(h)
 		if len(*h) == limit {
 			x := *h
 			x = x[:len(x)-1]

--- a/hit.go
+++ b/hit.go
@@ -295,7 +295,7 @@ type HitStats []HitStat
 
 var allDays = []int{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0}
 
-func (h *HitStats) List(ctx context.Context, start, end time.Time, exclude []string) (int, int, bool, error) {
+func (h *HitStats) List(ctx context.Context, start, end time.Time, filter string, exclude []string) (int, int, bool, error) {
 	db := zdb.MustGet(ctx)
 	site := MustGetSite(ctx)
 	l := zlog.Module("HitStats.List")
@@ -320,8 +320,14 @@ func (h *HitStats) List(ctx context.Context, start, end time.Time, exclude []str
 			site=? and
 			bot=0 and
 			created_at >= ? and
-			created_at <= ?`
+			created_at <= ? `
 	args := []interface{}{site.ID, dayStart(start), dayEnd(end)}
+
+	if filter != "" {
+		filter = "%" + strings.ToLower(filter) + "%"
+		query += ` and (lower(path) like ? or lower(title) like ?) `
+		args = append(args, filter, filter)
+	}
 
 	// Quite a bit faster to not check path.
 	if len(exclude) > 0 {
@@ -360,16 +366,22 @@ func (h *HitStats) List(ctx context.Context, start, end time.Time, exclude []str
 		Day   time.Time `db:"day"`
 		Stats []byte    `db:"stats"`
 	}
-	var st []stats
-	err = db.SelectContext(ctx, &st, `
+	query = `
 		select path, title, day, stats
 		from hit_stats
 		where
 			site=$1 and
 			day >= $2 and
-			day <= $3
-		order by day asc`,
-		site.ID, start.Format("2006-01-02"), end.Format("2006-01-02"))
+			day <= $3 `
+	args = []interface{}{site.ID, start.Format("2006-01-02"), end.Format("2006-01-02")}
+	if filter != "" {
+		query += ` and (lower(path) like $4 or lower(title) like $4) `
+		args = append(args, filter)
+	}
+	query += ` order by day asc`
+
+	var st []stats
+	err = db.SelectContext(ctx, &st, query, args...)
 	if err != nil {
 		return 0, 0, false, errors.Wrap(err, "HitStats.List")
 	}
@@ -433,16 +445,22 @@ func (h *HitStats) List(ctx context.Context, start, end time.Time, exclude []str
 	l = l.Since("fill blanks")
 
 	// Get total.
-	total := 0
-	err = db.GetContext(ctx, &total, `
+	query = `
 		select count(path)
 		from hits
 		where
 			site=$1 and
 			bot=0 and
 			created_at >= $2 and
-			created_at <= $3`,
-		site.ID, dayStart(start), dayEnd(end))
+			created_at <= $3 `
+	args = []interface{}{site.ID, dayStart(start), dayEnd(end)}
+	if filter != "" {
+		query += ` and (lower(path) like $4 or lower(title) like $4) `
+		args = append(args, filter)
+	}
+
+	total := 0
+	err = db.GetContext(ctx, &total, query, args...)
 
 	l = l.Since("get total")
 	return total, totalDisplay, more, errors.Wrap(err, "HitStats.List")
@@ -516,7 +534,7 @@ type Stats []struct {
 }
 
 // List all browser statistics for the given time period.
-func (h *Stats) ListBrowsers(ctx context.Context, start, end time.Time) (int, int, error) {
+func (h *Stats) ListBrowsers(ctx context.Context, start, end time.Time, filter string) (int, int, error) {
 	err := zdb.MustGet(ctx).SelectContext(ctx, h, `
 		select browser as name, sum(count) as count from browser_stats
 		where site=$1 and day >= $2 and day <= $3
@@ -533,19 +551,20 @@ func (h *Stats) ListBrowsers(ctx context.Context, start, end time.Time) (int, in
 	}
 
 	// List number of mobile browsers.
-	var m *int
-	err = zdb.MustGet(ctx).GetContext(ctx, &m, `
-		select sum(count) from browser_stats
-		where site=$1 and day >= $2 and day <= $3 and mobile=true
-	`, MustGetSite(ctx).ID, start.Format("2006-01-02"), end.Format("2006-01-02"))
-	if err != nil {
-		return 0, 0, errors.Wrap(err, "Stats.ListBrowsers mobile")
-	}
+	// TODO: inaccurate and not shown in UI at the moment.
+	//var m *int
+	//err = zdb.MustGet(ctx).GetContext(ctx, &m, `
+	//	select sum(count) from browser_stats
+	//	where site=$1 and day >= $2 and day <= $3 and mobile=true
+	//`, MustGetSite(ctx).ID, start.Format("2006-01-02"), end.Format("2006-01-02"))
+	//if err != nil {
+	//	return 0, 0, errors.Wrap(err, "Stats.ListBrowsers mobile")
+	//}
 
 	mobile := 0
-	if m != nil {
-		mobile = *m
-	}
+	//if m != nil {
+	//	mobile = *m
+	//}
 
 	return total, mobile, nil
 }
@@ -582,7 +601,7 @@ const (
 )
 
 // ListSizes lists all device sizes.
-func (h *Stats) ListSizes(ctx context.Context, start, end time.Time) error {
+func (h *Stats) ListSizes(ctx context.Context, start, end time.Time, filter string) error {
 	// TODO: just store better; all of this is ugly.
 	// select split_part(size, ',', 1) || ',' || split_part(size, ',', 2) as browser,
 	// order by cast(split_part(size, ',', 1) as int) asc
@@ -709,7 +728,7 @@ func (h *Stats) ListSize(ctx context.Context, name string, start, end time.Time)
 }
 
 // List all location statistics for the given time period.
-func (h *Stats) ListLocations(ctx context.Context, start, end time.Time) (int, error) {
+func (h *Stats) ListLocations(ctx context.Context, start, end time.Time, filter string) (int, error) {
 	err := zdb.MustGet(ctx).SelectContext(ctx, h, `
 		select
 			iso_3166_1.name as name,

--- a/hit_test.go
+++ b/hit_test.go
@@ -19,6 +19,14 @@ import (
 	"zgo.at/ztest"
 )
 
+func dayStat(days map[int]int) []int {
+	s := make([]int, 24)
+	for k, v := range days {
+		s[k] = v
+	}
+	return s
+}
+
 func TestHitStatsList(t *testing.T) {
 	start := time.Date(2019, 8, 10, 14, 42, 0, 0, time.UTC)
 	end := time.Date(2019, 8, 17, 14, 42, 0, 0, time.UTC)
@@ -39,24 +47,24 @@ func TestHitStatsList(t *testing.T) {
 			wantReturn: "3 3 false <nil>",
 			wantStats: goatcounter.HitStats{
 				goatcounter.HitStat{Count: 2, Max: 10, Path: "/asd", RefScheme: nil, Stats: []goatcounter.Stat{
-					{Day: "2019-08-10", Days: []int{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0}},
-					{Day: "2019-08-11", Days: []int{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0}},
-					{Day: "2019-08-12", Days: []int{0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0}},
-					{Day: "2019-08-13", Days: []int{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0}},
-					{Day: "2019-08-14", Days: []int{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0}},
-					{Day: "2019-08-15", Days: []int{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0}},
-					{Day: "2019-08-16", Days: []int{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0}},
-					{Day: "2019-08-17", Days: []int{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0}},
+					{Day: "2019-08-10", Days: dayStat(map[int]int{14: 1})},
+					{Day: "2019-08-11", Days: dayStat(nil)},
+					{Day: "2019-08-12", Days: dayStat(map[int]int{6: 1})},
+					{Day: "2019-08-13", Days: dayStat(nil)},
+					{Day: "2019-08-14", Days: dayStat(nil)},
+					{Day: "2019-08-15", Days: dayStat(nil)},
+					{Day: "2019-08-16", Days: dayStat(nil)},
+					{Day: "2019-08-17", Days: dayStat(nil)},
 				}},
 				goatcounter.HitStat{Count: 1, Max: 10, Path: "/zxc", RefScheme: nil, Stats: []goatcounter.Stat{
-					{Day: "2019-08-10", Days: []int{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0}},
-					{Day: "2019-08-11", Days: []int{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0}},
-					{Day: "2019-08-12", Days: []int{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0}},
-					{Day: "2019-08-13", Days: []int{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0}},
-					{Day: "2019-08-14", Days: []int{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0}},
-					{Day: "2019-08-15", Days: []int{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0}},
-					{Day: "2019-08-16", Days: []int{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0}},
-					{Day: "2019-08-17", Days: []int{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0}},
+					{Day: "2019-08-10", Days: dayStat(nil)},
+					{Day: "2019-08-11", Days: dayStat(nil)},
+					{Day: "2019-08-12", Days: dayStat(nil)},
+					{Day: "2019-08-13", Days: dayStat(nil)},
+					{Day: "2019-08-14", Days: dayStat(map[int]int{18: 1})},
+					{Day: "2019-08-15", Days: dayStat(nil)},
+					{Day: "2019-08-16", Days: dayStat(nil)},
+					{Day: "2019-08-17", Days: dayStat(nil)},
 				}},
 			},
 		},
@@ -69,14 +77,79 @@ func TestHitStatsList(t *testing.T) {
 			wantReturn: "1 1 false <nil>",
 			wantStats: goatcounter.HitStats{
 				goatcounter.HitStat{Count: 1, Max: 10, Path: "/zxc", RefScheme: nil, Stats: []goatcounter.Stat{
-					{Day: "2019-08-10", Days: []int{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0}},
-					{Day: "2019-08-11", Days: []int{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0}},
-					{Day: "2019-08-12", Days: []int{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0}},
-					{Day: "2019-08-13", Days: []int{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0}},
-					{Day: "2019-08-14", Days: []int{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0}},
-					{Day: "2019-08-15", Days: []int{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0}},
-					{Day: "2019-08-16", Days: []int{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0}},
-					{Day: "2019-08-17", Days: []int{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0}},
+					{Day: "2019-08-10", Days: dayStat(map[int]int{14: 1})},
+					{Day: "2019-08-11", Days: dayStat(nil)},
+					{Day: "2019-08-12", Days: dayStat(nil)},
+					{Day: "2019-08-13", Days: dayStat(nil)},
+					{Day: "2019-08-14", Days: dayStat(nil)},
+					{Day: "2019-08-15", Days: dayStat(nil)},
+					{Day: "2019-08-16", Days: dayStat(nil)},
+					{Day: "2019-08-17", Days: dayStat(nil)},
+				}},
+			},
+		},
+		{
+			in: []goatcounter.Hit{
+				{CreatedAt: start, Path: "/a"},
+				{CreatedAt: start, Path: "/aa"},
+				{CreatedAt: start, Path: "/aaa"},
+				{CreatedAt: start, Path: "/aaaa"},
+			},
+			inFilter:   "a",
+			wantReturn: "4 2 true <nil>",
+			wantStats: goatcounter.HitStats{
+				goatcounter.HitStat{Count: 1, Max: 10, Path: "/aaaa", RefScheme: nil, Stats: []goatcounter.Stat{
+					{Day: "2019-08-10", Days: dayStat(map[int]int{14: 1})},
+					{Day: "2019-08-11", Days: dayStat(nil)},
+					{Day: "2019-08-12", Days: dayStat(nil)},
+					{Day: "2019-08-13", Days: dayStat(nil)},
+					{Day: "2019-08-14", Days: dayStat(nil)},
+					{Day: "2019-08-15", Days: dayStat(nil)},
+					{Day: "2019-08-16", Days: dayStat(nil)},
+					{Day: "2019-08-17", Days: dayStat(nil)},
+				}},
+				goatcounter.HitStat{Count: 1, Max: 10, Path: "/aaa", RefScheme: nil, Stats: []goatcounter.Stat{
+					{Day: "2019-08-10", Days: dayStat(map[int]int{14: 1})},
+					{Day: "2019-08-11", Days: dayStat(nil)},
+					{Day: "2019-08-12", Days: dayStat(nil)},
+					{Day: "2019-08-13", Days: dayStat(nil)},
+					{Day: "2019-08-14", Days: dayStat(nil)},
+					{Day: "2019-08-15", Days: dayStat(nil)},
+					{Day: "2019-08-16", Days: dayStat(nil)},
+					{Day: "2019-08-17", Days: dayStat(nil)},
+				}},
+			},
+		},
+		{
+			in: []goatcounter.Hit{
+				{CreatedAt: start, Path: "/a"},
+				{CreatedAt: start, Path: "/aa"},
+				{CreatedAt: start, Path: "/aaa"},
+				{CreatedAt: start, Path: "/aaaa"},
+			},
+			inFilter:   "a",
+			inExclude:  []string{"/aaaa", "/aaa"},
+			wantReturn: "4 2 false <nil>",
+			wantStats: goatcounter.HitStats{
+				goatcounter.HitStat{Count: 1, Max: 10, Path: "/aa", RefScheme: nil, Stats: []goatcounter.Stat{
+					{Day: "2019-08-10", Days: dayStat(map[int]int{14: 1})},
+					{Day: "2019-08-11", Days: dayStat(nil)},
+					{Day: "2019-08-12", Days: dayStat(nil)},
+					{Day: "2019-08-13", Days: dayStat(nil)},
+					{Day: "2019-08-14", Days: dayStat(nil)},
+					{Day: "2019-08-15", Days: dayStat(nil)},
+					{Day: "2019-08-16", Days: dayStat(nil)},
+					{Day: "2019-08-17", Days: dayStat(nil)},
+				}},
+				goatcounter.HitStat{Count: 1, Max: 10, Path: "/a", RefScheme: nil, Stats: []goatcounter.Stat{
+					{Day: "2019-08-10", Days: dayStat(map[int]int{14: 1})},
+					{Day: "2019-08-11", Days: dayStat(nil)},
+					{Day: "2019-08-12", Days: dayStat(nil)},
+					{Day: "2019-08-13", Days: dayStat(nil)},
+					{Day: "2019-08-14", Days: dayStat(nil)},
+					{Day: "2019-08-15", Days: dayStat(nil)},
+					{Day: "2019-08-16", Days: dayStat(nil)},
+					{Day: "2019-08-17", Days: dayStat(nil)},
 				}},
 			},
 		},
@@ -93,6 +166,7 @@ func TestHitStatsList(t *testing.T) {
 					tt.in[j].Site = site.ID
 				}
 			}
+			site.Settings.Limits.Page = 2
 
 			goatcounter.Memstore.Append(tt.in...)
 			db := zdb.MustGet(ctx).(*sqlx.DB)

--- a/pack/pack.go
+++ b/pack/pack.go
@@ -11829,8 +11829,7 @@ http://nicolasgallagher.com/micro-clearfix-hack/
 	// Reload the path list when typing in the filter input, so the user won't
 	// have to press "enter".
 	var filter_paths = function() {
-		if ($('#filter-paths').val() !== '')
-			highlight_filter($('#filter-paths').val());
+		highlight_filter($('#filter-paths').val());
 
 		var t;
 		$('#filter-paths').on('input', function(e) {
@@ -11841,21 +11840,34 @@ http://nicolasgallagher.com/micro-clearfix-hack/
 				$('#filter-paths').toggleClass('value', filter !== '');
 
 				jQuery.ajax({
-					url: '/pages',
-					data: append_period({filter: filter}),
-					success: function(data) { xxx(data, true); },
+					url:     '/pages',
+					data:    append_period({filter: filter}),
+					success: function(data) { update_pages(data, true); },
 				});
 			}, 300);
 		});
 	};
 
-	var xxx = function(data, filter) {
-		if (filter)
+	// Paginate the main path overview.
+	var paginate_paths = function() {
+		$('.pages-list .load-more').on('click', function(e) {
+			e.preventDefault();
+			jQuery.ajax({
+				url: $(this).attr('data-href'),
+				success: function(data) { update_pages(data, false); },
+			});
+		});
+	};
+
+	// Update the page list from ajax request on pagination/filter.
+	var update_pages = function(data, from_filter) {
+		if (from_filter)
 			$('.pages-list .count-list-pages > tbody').html(data.rows);
 		else
 			$('.pages-list .count-list-pages > tbody').append(data.rows);
 
-		highlight_filter($('#filter-paths').val());
+		var filter = $('#filter-paths').val();
+		highlight_filter(filter);
 
 		if (!data.more)
 			$('.pages-list .load-more').css('display', 'none')
@@ -11864,19 +11876,21 @@ http://nicolasgallagher.com/micro-clearfix-hack/
 			var more   = $('.pages-list .load-more'),
 				params = split_query(more.attr('data-href'));
 			params['filter'] = filter;
-			params['exclude'] += data.paths.join(',');
+			if (from_filter)  // Clear pagination when filter changes.
+				params['exclude'] = data.paths.join(',');
+			else
+				params['exclude'] += ',' + data.paths.join(',');
 			more.attr('data-href', '/pages' + join_query(params));
 		}
 
 		var th = $('.pages-list .total-hits'),
 			td = $('.pages-list .total-display');
-		if (filter) {
+		if (from_filter) {
 			th.text(format_int(data.total_hits));
 			td.text(format_int(data.total_display));
 		}
-		else {
+		else
 			td.text(format_int(parseInt(td.text().replace(/\s/, ''), 10) + data.total_display));
-		}
 	};
 
 	// Highlight a filter pattern in the path and title.
@@ -12042,18 +12056,6 @@ http://nicolasgallagher.com/micro-clearfix-hack/
 					total: bar.attr('data-total'),
 				}),
 				success: function(data) { bar.html(data.html); },
-			});
-		});
-	};
-
-	// Paginate the main path overview.
-	var paginate_paths = function() {
-		$('.pages-list .load-more').on('click', function(e) {
-			e.preventDefault();
-
-			jQuery.ajax({
-				url: $(this).attr('data-href'),
-				success: function(data) { xxx(data, false); },
 			});
 		});
 	};

--- a/pack/pack.go
+++ b/pack/pack.go
@@ -11853,7 +11853,7 @@ http://nicolasgallagher.com/micro-clearfix-hack/
 		$('.pages-list .load-more').on('click', function(e) {
 			e.preventDefault();
 			jQuery.ajax({
-				url: $(this).attr('data-href'),
+				url:     $(this).attr('data-href'),
 				success: function(data) { update_pages(data, false); },
 			});
 		});
@@ -11874,7 +11874,7 @@ http://nicolasgallagher.com/micro-clearfix-hack/
 		else {
 			$('.pages-list .load-more').css('display', 'inline')
 			var more   = $('.pages-list .load-more'),
-				params = split_query(more.attr('data-href'));
+			    params = split_query(more.attr('data-href'));
 			params['filter'] = filter;
 			if (from_filter)  // Clear pagination when filter changes.
 				params['exclude'] = data.paths.join(',');
@@ -11884,7 +11884,7 @@ http://nicolasgallagher.com/micro-clearfix-hack/
 		}
 
 		var th = $('.pages-list .total-hits'),
-			td = $('.pages-list .total-display');
+		    td = $('.pages-list .total-display');
 		if (from_filter) {
 			th.text(format_int(data.total_hits));
 			td.text(format_int(data.total_display));

--- a/pack/pack.go
+++ b/pack/pack.go
@@ -13780,11 +13780,14 @@ parameters:</p>
 		<input type="text" autocomplete="off" title="End of date range to display"   id="period-end"   name="period-end"   value="{{tformat .PeriodEnd ""}}">
 		<input type="hidden" id="hl-period" name="hl-period" value="">
 		<button type="submit">Go</button>
+
+		<input name="filter" value="{{.Filter}}" placeholder="Filter">
 	</form>
 </div>
 
 <div class="pages-list">
 	<h2>Pages <sup>(total {{nformat .TotalHits}} hits{{if ne .TotalHits .TotalHitsDisplay}}, <span class="total-display">{{nformat .TotalHitsDisplay}}</span> displayed{{end}})</sup></h2>
+
 	{{if eq .TotalHits 0}}
 		<em>Nothing to display</em>
 	{{else}}

--- a/public/script_backend.js
+++ b/public/script_backend.js
@@ -55,7 +55,7 @@
 		$('.pages-list .load-more').on('click', function(e) {
 			e.preventDefault();
 			jQuery.ajax({
-				url: $(this).attr('data-href'),
+				url:     $(this).attr('data-href'),
 				success: function(data) { update_pages(data, false); },
 			});
 		});
@@ -76,7 +76,7 @@
 		else {
 			$('.pages-list .load-more').css('display', 'inline')
 			var more   = $('.pages-list .load-more'),
-				params = split_query(more.attr('data-href'));
+			    params = split_query(more.attr('data-href'));
 			params['filter'] = filter;
 			if (from_filter)  // Clear pagination when filter changes.
 				params['exclude'] = data.paths.join(',');
@@ -86,7 +86,7 @@
 		}
 
 		var th = $('.pages-list .total-hits'),
-			td = $('.pages-list .total-display');
+		    td = $('.pages-list .total-display');
 		if (from_filter) {
 			th.text(format_int(data.total_hits));
 			td.text(format_int(data.total_display));

--- a/public/script_backend.js
+++ b/public/script_backend.js
@@ -31,6 +31,15 @@
 	// Reload the path list when typing in the filter input, so the user won't
 	// have to press "enter".
 	var filter_paths = function() {
+		var highlight = function(s) {
+			$('.pages-list .count-list-pages > tbody').find('.rlink, .page-title').each(function(_, elem) {
+				elem.innerHTML = replacei(elem.innerHTML, s, function(s) { return '<em>' + s + '</em>'; });
+			});
+		};
+
+		if ($('#filter-paths').val() !== '')
+			highlight($('#filter-paths').val());
+
 		var t;
 		$('#filter-paths').on('input', function(e) {
 			clearTimeout(t);
@@ -41,11 +50,10 @@
 
 				jQuery.ajax({
 					url: '/pages',
-					data: append_period({
-						filter: $(e.target).val(),
-					}),
+					data: append_period({filter: filter}),
 					success: function(data) {
 						$('.pages-list .count-list-pages > tbody').html(data.rows);
+						highlight(filter);
 
 						if (!data.more)
 							$('.pages-list .load-more').css('display', 'none')
@@ -60,7 +68,6 @@
 						td.text(parseInt(td.text().replace(/\s/, ''), 10) + data.total_display);
 					},
 				});
-
 			}, 300);
 		});
 	};
@@ -618,4 +625,19 @@
 			return true;
 		return window.innerWidth <= 800 && window.innerHeight <= 600;
 	};
+
+	// Case-insensitive string replace. https://stackoverflow.com/a/42215678/660921
+	var replacei = function(str, sub, f) {
+		var A = str.toLowerCase().split(sub.toLowerCase()),
+		    B = [],
+		    x = 0;
+		for (var i = 0; i < A.length; i++) {
+			var n = A[i].length;
+			B.push(str.substr(x, n));
+			if (i < A.length-1)
+				B.push(f(str.substr(x + n, sub.length)));
+			x += n + sub.length;
+		}
+		return B.join('');
+	}
 })();

--- a/public/script_backend.js
+++ b/public/script_backend.js
@@ -23,10 +23,45 @@
 
 		[period_select, drag_timeframe, load_refs, chart_hover, paginate_paths,
 			paginate_refs, browser_detail, settings_tabs, paginate_locations,
-			billing_subscribe, setup_datepicker,
+			billing_subscribe, setup_datepicker, filter_paths,
 		].forEach(function(f) { f.call(); });
 
 	});
+
+	// Reload the path list when typing in the filter input, so the user won't
+	// have to press "enter".
+	var filter_paths = function() {
+		var t;
+		$('#filter-paths').on('input', function(e) {
+			clearTimeout(t);
+			t = setTimeout(function() {
+				set_param('filter', $(e.target).val());
+
+				jQuery.ajax({
+					url: '/pages',
+					data: append_period({
+						filter: $(e.target).val(),
+					}),
+					success: function(data) {
+						$('.pages-list .count-list-pages > tbody').html(data.rows);
+
+						if (!data.more)
+							$('.pages-list .load-more').css('display', 'none')
+						else {
+							$('.pages-list .load-more').css('display', 'inline')
+							// TODO: set filter here.
+							var b = $('.pages-list .load-more');
+							b.attr('data-href', b.attr('data-href') + ',' +  data.paths.join(','));
+						}
+
+						var td = $('.pages-list .total-display');
+						td.text(parseInt(td.text().replace(/\s/, ''), 10) + data.total_display);
+					},
+				});
+
+			}, 300);
+		});
+	};
 
 	// Setup datepicker fields.
 	var setup_datepicker = function() {
@@ -197,8 +232,9 @@
 					$('.pages-list .count-list-pages > tbody').append(data.rows);
 
 					if (!data.more)
-						$('.pages-list .load-more').remove()
+						$('.pages-list .load-more').css('display', 'none')
 					else {
+						$('.pages-list .load-more').css('display', 'inline')
 						var b = $('.pages-list .load-more');
 						b.attr('data-href', b.attr('data-href') + ',' +  data.paths.join(','));
 					}

--- a/public/script_backend.js
+++ b/public/script_backend.js
@@ -35,7 +35,9 @@
 		$('#filter-paths').on('input', function(e) {
 			clearTimeout(t);
 			t = setTimeout(function() {
-				set_param('filter', $(e.target).val());
+				var filter = $(e.target).val().trim();
+				set_param('filter', filter);
+				$('#filter-paths').toggleClass('value', filter !== '');
 
 				jQuery.ajax({
 					url: '/pages',

--- a/public/style_backend.css
+++ b/public/style_backend.css
@@ -298,3 +298,10 @@ noscript {
 /*** Updates overview ***/
 .update p        { margin-left: 2em; }
 .update > em + p { margin-top: 0; }
+
+/*** Pages header ***/
+header h2 { border-bottom: 0; display: inline; }
+header.h2 { border-bottom: 1px solid #252525; padding-bottom: .2em; margin: 1em 0; }
+
+.header-pages sup   { font-size: .9rem; }
+.header-pages input { float: right; border: 1px solid #ccc; padding: .2em; margin-right: 1em; border-radius: 2px; }

--- a/public/style_backend.css
+++ b/public/style_backend.css
@@ -63,6 +63,8 @@ form .err  { color: red; display: block; }
 	border-color: #f00;
 }
 
+
+/*** Pages list ***/
 .count-list td {
 	vertical-align: top;
 }
@@ -108,6 +110,7 @@ form .err  { color: red; display: block; }
 	border-bottom: 4px solid yellow;
 }
 
+/*** Pages header (filter, time period select, etc.) ***/
 .count-list-opt {
 	padding: 1em;
 	background-color: #f8f8d9;
@@ -128,6 +131,7 @@ form .err  { color: red; display: block; }
 
 .count-list-opt input { width: 9em; text-align: center; }
 
+/*** Charts ***/
 .chart {
 	border: 1px solid #ccc;
 	height: 50px;
@@ -303,5 +307,6 @@ noscript {
 header h2 { border-bottom: 0; display: inline; }
 header.h2 { border-bottom: 1px solid #252525; padding-bottom: .2em; margin: 1em 0; }
 
-.header-pages sup   { font-size: .9rem; }
-.header-pages input { float: right; border: 1px solid #ccc; padding: .2em; margin-right: 1em; border-radius: 2px; }
+.header-pages sup         { font-size: .9rem; }
+.header-pages input       { float: right; border: 1px solid #ccc; padding: .2em; margin-right: 1em; border-radius: 2px; }
+.header-pages input.value { background-color: yellow; }

--- a/public/style_backend.css
+++ b/public/style_backend.css
@@ -94,6 +94,11 @@ form .err  { color: red; display: block; }
 .rlink {
 	min-width: 3em;   /* Make very short paths (like just /) easier to click/touch. */
 }
+.page-title em, .rlink em {
+	font-style: normal;
+	background-color: yellow;
+	font-weight: bold;
+}
 
 .count-list tr {
 	border: none;

--- a/public/style_backend.css
+++ b/public/style_backend.css
@@ -76,6 +76,10 @@ form .err  { color: red; display: block; }
 	text-align: right;
 	width: 5em;
 }
+.count-list td[colspan="3"] {  /* "nothing to display" */
+	text-align: left;
+	width: auto;
+}
 
 .count-list td:nth-child(2) {  /* Path */
 	width: 20em;
@@ -94,11 +98,7 @@ form .err  { color: red; display: block; }
 .rlink {
 	min-width: 3em;   /* Make very short paths (like just /) easier to click/touch. */
 }
-.page-title em, .rlink em {
-	font-style: normal;
-	background-color: yellow;
-	font-weight: bold;
-}
+.page-title b, .rlink b { background-color: yellow; }
 
 .count-list tr {
 	border: none;

--- a/tpl/_backend_pages.gohtml
+++ b/tpl/_backend_pages.gohtml
@@ -24,4 +24,6 @@
 			{{end}}</div>
 		</td>
 	</tr>
+{{else}}
+	<tr><td colspan="3"><em>Nothing to display</em></td></tr>
 {{- end}}

--- a/tpl/backend.gohtml
+++ b/tpl/backend.gohtml
@@ -51,7 +51,7 @@
 		<header class="h2 header-pages">
 			<h2>Pages</h2>
 			<sup>(total {{nformat .TotalHits}} hits{{if ne .TotalHits .TotalHitsDisplay}}, <span class="total-display">{{nformat .TotalHitsDisplay}}</span> displayed{{end}})</sup>
-			<input name="filter" value="{{.Filter}}" id="filter-paths" placeholder="Filter paths"
+			<input autocomplete="off" name="filter" value="{{.Filter}}" id="filter-paths" placeholder="Filter paths"
 				{{if .Filter}}class="value"{{end}}
 				title="Filter the list of paths; matched case-insensitive on path and title">
 		</header>
@@ -86,7 +86,7 @@
 		{{if eq .TotalHits 0}}
 			<em>Nothing to display</em>
 		{{else}}
-			<div class="chart-hbar" data-detail="/sizes">{{hbar_chart .SizeStat .TotalHits 0 0.1 true}}</div>
+			<div class="chart-hbar" data-detail="/sizes">{{hbar_chart .SizeStat .TotalSize 0 0.1 true}}</div>
 			<p><small>The screen sizes are an indication and influenced by DPI and zoom levels.
 				{{/*Approximately {{.TotalMobile}}% advertised the usage of a mobile browser.*/}}
 			</small></p>

--- a/tpl/backend.gohtml
+++ b/tpl/backend.gohtml
@@ -17,8 +17,8 @@
 
 {{if and .Site.Settings.Public (not .User.ID)}}<div class="flash flash-i"><p>Note: public view is updated once an hour. Sign in to get real-time statistics.</p></div>{{end}}
 
-<div class="count-list-opt">
-	<form id="period-form">
+<form id="period-form">
+	<div class="count-list-opt">
 		{{/* The first button gets used on the enter key, AFAICT there is no way to change that. */}}
 		<button type="submit" class="hide-btn"></button>
 
@@ -45,28 +45,31 @@
 		<input type="text" autocomplete="off" title="End of date range to display"   id="period-end"   name="period-end"   value="{{tformat .PeriodEnd ""}}">
 		<input type="hidden" id="hl-period" name="hl-period" value="">
 		<button type="submit">Go</button>
+	</div>
 
-		<input name="filter" value="{{.Filter}}" placeholder="Filter">
-	</form>
-</div>
+	<div class="pages-list">
+		<header class="h2 header-pages">
+			<h2>Pages</h2>
+			<sup>(total {{nformat .TotalHits}} hits{{if ne .TotalHits .TotalHitsDisplay}}, <span class="total-display">{{nformat .TotalHitsDisplay}}</span> displayed{{end}})</sup>
+			<input name="filter" value="{{.Filter}}" id="filter-paths" placeholder="Filter paths"
+				title="Filter the list of paths; matched case-insensitive on path and title">
+		</header>
 
-<div class="pages-list">
-	<h2>Pages <sup>(total {{nformat .TotalHits}} hits{{if ne .TotalHits .TotalHitsDisplay}}, <span class="total-display">{{nformat .TotalHitsDisplay}}</span> displayed{{end}})</sup></h2>
+		{{if eq .TotalHits 0}}
+			<em>Nothing to display</em>
+		{{else}}
+			<table class="count-list count-list-pages">
+				<tbody>{{template "_backend_pages.gohtml" .}}</tbody>
+			</table>
+		{{end}}
 
-	{{if eq .TotalHits 0}}
-		<em>Nothing to display</em>
-	{{else}}
-		<table class="count-list count-list-pages">
-			<tbody>{{template "_backend_pages.gohtml" .}}</tbody>
-		</table>
-	{{end}}
-
-	{{if gt .TotalHits .TotalHitsDisplay}}
-		<a href="#_", class="load-more"
-			data-href="/pages?period-start={{tformat $.PeriodStart ""}}&period-end={{tformat $.PeriodEnd ""}}&exclude={{range $h := .Pages}}{{$h.Path}},{{end}}"
-		>load more</a>
-	{{end}}
-</div>
+		{{if gt .TotalHits .TotalHitsDisplay}}
+			<a href="#_", class="load-more"
+				data-href="/pages?period-start={{tformat $.PeriodStart ""}}&period-end={{tformat $.PeriodEnd ""}}&filter={{.Filter}}&exclude={{range $h := .Pages}}{{$h.Path}},{{end}}"
+			>load more</a>
+		{{end}}
+	</div>
+</form>
 
 <div class="browser-charts">
 	<div>
@@ -93,7 +96,7 @@
 		{{if eq .TotalHits 0}}
 			<em>Nothing to display</em>
 		{{else}}
-			<div class="chart-hbar">{{hbar_chart .LocationStat .TotalHits 0 3 false}}</div>
+			<div class="chart-hbar">{{hbar_chart .LocationStat .TotalLocation 0 3 false}}</div>
 			{{if .ShowMoreLocations}}<a href="#" class="show-all">Show all</a>{{end}}
 		{{end}}
 	</div>

--- a/tpl/backend.gohtml
+++ b/tpl/backend.gohtml
@@ -45,11 +45,14 @@
 		<input type="text" autocomplete="off" title="End of date range to display"   id="period-end"   name="period-end"   value="{{tformat .PeriodEnd ""}}">
 		<input type="hidden" id="hl-period" name="hl-period" value="">
 		<button type="submit">Go</button>
+
+		<input name="filter" value="{{.Filter}}" placeholder="Filter">
 	</form>
 </div>
 
 <div class="pages-list">
 	<h2>Pages <sup>(total {{nformat .TotalHits}} hits{{if ne .TotalHits .TotalHitsDisplay}}, <span class="total-display">{{nformat .TotalHitsDisplay}}</span> displayed{{end}})</sup></h2>
+
 	{{if eq .TotalHits 0}}
 		<em>Nothing to display</em>
 	{{else}}

--- a/tpl/backend.gohtml
+++ b/tpl/backend.gohtml
@@ -50,25 +50,19 @@
 	<div class="pages-list">
 		<header class="h2 header-pages">
 			<h2>Pages</h2>
-			<sup>(total {{nformat .TotalHits}} hits{{if ne .TotalHits .TotalHitsDisplay}}, <span class="total-display">{{nformat .TotalHitsDisplay}}</span> displayed{{end}})</sup>
+			<sup>(total <span class="total-hits">{{nformat .TotalHits}}</span> hits, <span class="total-display">{{nformat .TotalHitsDisplay}}</span> displayed)</sup>
 			<input autocomplete="off" name="filter" value="{{.Filter}}" id="filter-paths" placeholder="Filter paths"
 				{{if .Filter}}class="value"{{end}}
 				title="Filter the list of paths; matched case-insensitive on path and title">
 		</header>
 
-		{{if eq .TotalHits 0}}
-			<em>Nothing to display</em>
-		{{else}}
-			<table class="count-list count-list-pages">
-				<tbody>{{template "_backend_pages.gohtml" .}}</tbody>
-			</table>
-		{{end}}
+		<table class="count-list count-list-pages">
+			<tbody>{{template "_backend_pages.gohtml" .}}</tbody>
+		</table>
 
-		{{if gt .TotalHits .TotalHitsDisplay}}
-			<a href="#_", class="load-more"
+		<a href="#_", class="load-more" {{if not (gt .TotalHits .TotalHitsDisplay)}}style="display: none"{{end}}
 				data-href="/pages?period-start={{tformat $.PeriodStart ""}}&period-end={{tformat $.PeriodEnd ""}}&filter={{.Filter}}&exclude={{range $h := .Pages}}{{$h.Path}},{{end}}"
-			>load more</a>
-		{{end}}
+		>load more</a>
 	</div>
 </form>
 

--- a/tpl/backend.gohtml
+++ b/tpl/backend.gohtml
@@ -52,6 +52,7 @@
 			<h2>Pages</h2>
 			<sup>(total {{nformat .TotalHits}} hits{{if ne .TotalHits .TotalHitsDisplay}}, <span class="total-display">{{nformat .TotalHitsDisplay}}</span> displayed{{end}})</sup>
 			<input name="filter" value="{{.Filter}}" id="filter-paths" placeholder="Filter paths"
+				{{if .Filter}}class="value"{{end}}
 				title="Filter the list of paths; matched case-insensitive on path and title">
 		</header>
 


### PR DESCRIPTION
Filtering the pages isn't too hard, and works.

The problem I ran in to here is that there is currently no way to filter
the browser_stat, size_stat, and location_stat by path/title. Guess I'll
have to add those columns, but don't really fancy making this data more
complicated.

Alternative might be to just filter this data and display these stats
as-is; I think that might actually be okay. Need to think about it.

Issue #62