### PR TITLE
Add description metadata

### DIFF
--- a/handlers/website.go
+++ b/handlers/website.go
@@ -69,6 +69,14 @@ func (h website) Mount(r *chi.Mux, db *sqlx.DB) {
 	user{}.mount(r)
 }
 
+var metaDesc = map[string]string{
+	"":        "Simple web statistics. No tracking of personal data.",
+	"help":    "Help and support – GoatCounter",
+	"privacy": "Privacy policy – GoatCounter",
+	"terms":   "Terms of Service – GoatCounter",
+	"contact": "Contact – GoatCounter",
+}
+
 func (h website) tpl(w http.ResponseWriter, r *http.Request) error {
 	t := r.URL.Path[1:]
 	if t == "" {
@@ -92,8 +100,9 @@ func (h website) tpl(w http.ResponseWriter, r *http.Request) error {
 	return zhttp.Template(w, t+".gohtml", struct {
 		Globals
 		Page     string
+		MetaDesc string
 		LoggedIn template.HTML
-	}{newGlobals(w, r), t, loggedIn})
+	}{newGlobals(w, r), t, metaDesc[t], loggedIn})
 }
 
 func (h website) status() func(w http.ResponseWriter, r *http.Request) error {
@@ -110,11 +119,12 @@ func (h website) signup(w http.ResponseWriter, r *http.Request) error {
 	return zhttp.Template(w, "signup.gohtml", struct {
 		Globals
 		Page       string
+		MetaDesc   string
 		Site       goatcounter.Site
 		User       goatcounter.User
 		Validate   map[string][]string
 		TuringTest string
-	}{newGlobals(w, r), "signup", goatcounter.Site{},
+	}{newGlobals(w, r), "signup", "Sign up for GoatCounter", goatcounter.Site{},
 		goatcounter.User{}, map[string][]string{}, ""})
 }
 
@@ -172,11 +182,12 @@ func (h website) doSignup(w http.ResponseWriter, r *http.Request) error {
 		return zhttp.Template(w, "signup.gohtml", struct {
 			Globals
 			Page       string
+			MetaDesc   string
 			Site       goatcounter.Site
 			User       goatcounter.User
 			Validate   map[string][]string
 			TuringTest string
-		}{newGlobals(w, r), "signup", site, user, v.Errors, args.TuringTest})
+		}{newGlobals(w, r), "signup", "Sign up for GoatCounter", site, user, v.Errors, args.TuringTest})
 	}
 
 	err = tx.Commit()

--- a/pack/pack.go
+++ b/pack/pack.go
@@ -13722,6 +13722,7 @@ parameters:</p>
 <head>
 	<meta http-equiv="Content-Type" content="text/html; charset=utf-8">
 	<meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1">
+	<meta name="description" content="{{.MetaDesc}}">
 	<title>GoatCounter – Website statistics for regular folks</title>
 	<link rel="icon" type="image/png" href="//{{.Static}}/favicon.png">
 	<link rel="apple-touch-icon" href="//{{.Static}}/apple-touch-icon.png">

--- a/tpl/_backend_top.gohtml
+++ b/tpl/_backend_top.gohtml
@@ -3,6 +3,7 @@
 <head>
 	<meta http-equiv="Content-Type" content="text/html; charset=utf-8">
 	<meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1">
+	<meta name="description" content="Simple web statistics. No tracking of personal data.">
 	<title>{{.Site.Name}} – GoatCounter</title>
 	<link rel="icon" type="image/png" href="//{{.Static}}/favicon.png">
 	<link rel="apple-touch-icon" href="//{{.Static}}/apple-touch-icon.png">

--- a/tpl/_backend_top.gohtml
+++ b/tpl/_backend_top.gohtml
@@ -3,7 +3,6 @@
 <head>
 	<meta http-equiv="Content-Type" content="text/html; charset=utf-8">
 	<meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1">
-	<meta name="description" content="Simple web statistics. No tracking of personal data.">
 	<title>{{.Site.Name}} – GoatCounter</title>
 	<link rel="icon" type="image/png" href="//{{.Static}}/favicon.png">
 	<link rel="apple-touch-icon" href="//{{.Static}}/apple-touch-icon.png">

--- a/tpl/_top.gohtml
+++ b/tpl/_top.gohtml
@@ -3,6 +3,7 @@
 <head>
 	<meta http-equiv="Content-Type" content="text/html; charset=utf-8">
 	<meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1">
+	<meta name="description" content="Simple web statistics. No tracking of personal data.">
 	<title>GoatCounter – Website statistics for regular folks</title>
 	<link rel="icon" type="image/png" href="//{{.Static}}/favicon.png">
 	<link rel="apple-touch-icon" href="//{{.Static}}/apple-touch-icon.png">

--- a/tpl/_top.gohtml
+++ b/tpl/_top.gohtml
@@ -3,7 +3,7 @@
 <head>
 	<meta http-equiv="Content-Type" content="text/html; charset=utf-8">
 	<meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1">
-	<meta name="description" content="Simple web statistics. No tracking of personal data.">
+	<meta name="description" content="{{.MetaDesc}}">
 	<title>GoatCounter – Website statistics for regular folks</title>
 	<link rel="icon" type="image/png" href="//{{.Static}}/favicon.png">
 	<link rel="apple-touch-icon" href="//{{.Static}}/apple-touch-icon.png">


### PR DESCRIPTION
Specific descriptions for the pages (i.e Privacy and Sign up) would be ideal but I don't know Go unfortunately 😞

Before:
![image](https://user-images.githubusercontent.com/3440094/72658339-5a911280-39a7-11ea-8e7d-9258e1d17d11.png)
![image](https://user-images.githubusercontent.com/3440094/72658348-8e6c3800-39a7-11ea-86e3-d9fcdad2e56c.png)

After:
![image](https://user-images.githubusercontent.com/3440094/72658343-798fa480-39a7-11ea-8db5-ca02868cfb6f.png)
![image](https://user-images.githubusercontent.com/3440094/72658354-a643bc00-39a7-11ea-83f7-14b465e29e76.png)


