### PR TITLE
(typo): Change 'trail' to 'trial'

### DIFF
--- a/public/style_backend.css
+++ b/public/style_backend.css
@@ -10,7 +10,7 @@ footer a { font-weight: bold; color: #252525; }
 /* Don't make various explanatory texts too wide. */
 .page > p, .page > div > p, .page > ul, .page > div > ul { max-width: 50em; }
 
-#trail-expired { position: fixed; bottom: 0; left: 0; right: 0; text-align: center;
+#trial-expired { position: fixed; bottom: 0; left: 0; right: 0; text-align: center;
                  background-color: #fff0f0; border-top: 1px solid #f00; }
 
 #settings { display: none; }

--- a/site.go
+++ b/site.go
@@ -346,7 +346,7 @@ func (s Site) IDOrParent() int64 {
 	return s.ID
 }
 
-var trailPeriod = time.Hour * 24 * 14
+var trialPeriod = time.Hour * 24 * 14
 
 func (s Site) ShowPayBanner(ctx context.Context) bool {
 	if s.Parent != nil {
@@ -362,7 +362,7 @@ func (s Site) ShowPayBanner(ctx context.Context) bool {
 	if s.Stripe != nil {
 		return false
 	}
-	return -time.Now().UTC().Sub(s.CreatedAt.Add(trailPeriod)) < 0
+	return -time.Now().UTC().Sub(s.CreatedAt.Add(trialPeriod)) < 0
 }
 
 func (s Site) FreePlan() bool {

--- a/tpl/_backend_bottom.gohtml
+++ b/tpl/_backend_bottom.gohtml
@@ -1,7 +1,7 @@
 	</div> {{- /* .page */}}
 	{{template "_bottom_links.gohtml" .}}
 	{{if and .User.ID .Billing (eq .Path "/") (.Site.ShowPayBanner .Context)}}
-		<div id="trail-expired">
+		<div id="trial-expired">
 			<p>Hey hey; you’ve been using GoatCounter for more than 14 days.
 			Please consider making a small donation to cover development costs,
 			or subscribe to a plan if you’re using it for commercial

--- a/tpl/terms.gohtml
+++ b/tpl/terms.gohtml
@@ -42,7 +42,7 @@
 
 <h2 id="commercial">Commercial use</h2>
 <p>The service is free for personal use, but all commercial users must purchase
-a plan after the initial 14-day trail or stop using the service until a plan is
+a plan after the initial 14-day trial or stop using the service until a plan is
 purchased. A website is considered “commercial” if the primary goal is to sell
 or advertise paid products or services.</p>
 


### PR DESCRIPTION
Hi there!

Fan of goatcounter, recently set it up on a couple of personal sites.

I was reading the terms and I noticed that they say:
> ...a plan after the initial 14-day trail...

and I think it should read "trial", so I went ahead and fixed it. I also changed the occurrences of the typo in code.

Feel free to ignore this, just wanted to send this patch over as a token of appreciation for the project. 
