### PR TITLE
Update the Readme to reflect the actual plan name

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -75,7 +75,7 @@ will need a C compiler (for SQLite) or PostgreSQL.
        goatcounter \
            -prod \
            -smtp         'smtp://localhost:25' \
-           -plan         'pro' \
+           -plan         'businessplus' \
            -domain       'example.com' \
            -domainstatic 'static.example.com' \
            -emailerrors  'me@example.com' \


### PR DESCRIPTION
I was bashing my head against the wall trying to figure our why this wasn't working due to a lack of error messages, turns out it was the altered constraint / schema from 66980b0