### PR TITLE
Remove recording of browsers are "mobile"

### DIFF
--- a/cron/browser_stat_test.go
+++ b/cron/browser_stat_test.go
@@ -30,13 +30,13 @@ func TestBrowserStats(t *testing.T) {
 	}
 
 	var stats goatcounter.Stats
-	total, totalMobile, err := stats.ListBrowsers(ctx, now, now)
+	total, err := stats.ListBrowsers(ctx, now, now)
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	want := `4 -> 0 -> [{Firefox false 3} {Chrome false 1}]`
-	out := fmt.Sprintf("%d -> %d -> %v", total, totalMobile, stats)
+	want := `4 -> [{Firefox 3} {Chrome 1}]`
+	out := fmt.Sprintf("%d -> %v", total, stats)
 	if want != out {
 		t.Errorf("\nwant: %s\nout:  %s", want, out)
 	}
@@ -52,13 +52,13 @@ func TestBrowserStats(t *testing.T) {
 	}
 
 	stats = goatcounter.Stats{}
-	total, totalMobile, err = stats.ListBrowsers(ctx, now, now)
+	total, err = stats.ListBrowsers(ctx, now, now)
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	want = `7 -> 0 -> [{Firefox false 6} {Chrome false 1}]`
-	out = fmt.Sprintf("%d -> %d -> %v", total, totalMobile, stats)
+	want = `7 -> [{Firefox 6} {Chrome 1}]`
+	out = fmt.Sprintf("%d -> %v", total, stats)
 	if want != out {
 		t.Errorf("\nwant: %s\nout:  %s", want, out)
 	}
@@ -70,7 +70,7 @@ func TestBrowserStats(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	want = `6 -> [{Firefox 69.0 false 4} {Firefox 68.0 false 1} {Firefox 70.0 false 1}]`
+	want = `6 -> [{Firefox 69.0 4} {Firefox 68.0 1} {Firefox 70.0 1}]`
 	out = fmt.Sprintf("%d -> %v", total, stats)
 	if want != out {
 		t.Errorf("\nwant: %s\nout:  %s", want, out)

--- a/cron/location_stat_test.go
+++ b/cron/location_stat_test.go
@@ -34,7 +34,7 @@ func TestLocationStats(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	want := `3 -> [{Indonesia false 2} {Ethiopia false 1}]`
+	want := `3 -> [{Indonesia 2} {Ethiopia 1}]`
 	out := fmt.Sprintf("%d -> %v", total, stats)
 	if want != out {
 		t.Errorf("\nwant: %s\nout:  %s", want, out)
@@ -60,7 +60,7 @@ func TestLocationStats(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	want = `10 -> [{Ethiopia false 5} {Indonesia false 4} {New Zealand false 1}]`
+	want = `10 -> [{Ethiopia 5} {Indonesia 4} {New Zealand 1}]`
 	out = fmt.Sprintf("%d -> %v", total, stats)
 	if want != out {
 		t.Errorf("\nwant: %s\nout:  %s", want, out)

--- a/db/migrate/pgsql/2020-01-24-1-rm-mobile.sql
+++ b/db/migrate/pgsql/2020-01-24-1-rm-mobile.sql
@@ -1,0 +1,5 @@
+begin;
+	alter table browser_stats drop column mobile;
+	insert into version values ('2020-01-24-1-rm-mobile');
+commit;
+

--- a/db/migrate/sqlite/2020-01-24-1-rm-mobile.sql
+++ b/db/migrate/sqlite/2020-01-24-1-rm-mobile.sql
@@ -1,0 +1,19 @@
+begin;
+	create table browser_stats2 (
+		site           integer        not null                 check(site > 0),
+
+		day            date           not null                 check(day = strftime('%Y-%m-%d', day)),
+		browser        varchar        not null,
+		version        varchar        not null,
+		count          int            not null,
+
+		foreign key (site) references sites(id) on delete restrict on update restrict
+	);
+
+	insert into browser_stats2 select site, day, browser, version, count from browser_stats;
+	drop table browser_stats;
+	alter table browser_stats2 rename to browser_stats;
+
+	insert into version values ('2020-01-24-1-rm-mobile');
+commit;
+

--- a/handlers/backend.go
+++ b/handlers/backend.go
@@ -293,7 +293,7 @@ func (h backend) index(w http.ResponseWriter, r *http.Request) error {
 	l = l.Since("pages.List")
 
 	var browsers goatcounter.Stats
-	totalBrowsers, totalMobile, err := browsers.ListBrowsers(r.Context(), start, end)
+	totalBrowsers, err := browsers.ListBrowsers(r.Context(), start, end)
 	if err != nil {
 		return err
 	}
@@ -345,7 +345,6 @@ func (h backend) index(w http.ResponseWriter, r *http.Request) error {
 		TotalHitsDisplay  int
 		Browsers          goatcounter.Stats
 		TotalBrowsers     int
-		TotalMobile       string
 		SubSites          []string
 		SizeStat          goatcounter.Stats
 		TotalSize         int
@@ -354,7 +353,6 @@ func (h backend) index(w http.ResponseWriter, r *http.Request) error {
 		ShowMoreLocations bool
 	}{newGlobals(w, r), sr, r.URL.Query().Get("hl-period"), start, end, filter,
 		pages, refs, moreRefs, total, totalDisplay, browsers, totalBrowsers,
-		fmt.Sprintf("%.1f", float32(totalMobile)/float32(totalBrowsers)*100),
 		subs, sizeStat, totalSize, locStat, totalLoc, showMoreLoc})
 	l = l.Since("zhttp.Template")
 	l.FieldsSince().Print("")

--- a/tpl/backend.gohtml
+++ b/tpl/backend.gohtml
@@ -81,9 +81,7 @@
 			<em>Nothing to display</em>
 		{{else}}
 			<div class="chart-hbar" data-detail="/sizes">{{hbar_chart .Context .SizeStat .TotalSize 0 0.1 true}}</div>
-			<p><small>The screen sizes are an indication and influenced by DPI and zoom levels.
-				{{/*Approximately {{.TotalMobile}}% advertised the usage of a mobile browser.*/}}
-			</small></p>
+			<p><small>The screen sizes are an indication and influenced by DPI and zoom levels.</small></p>
 		{{end}}
 	</div>
 	<div class="location-chart">


### PR DESCRIPTION
This didn't work well anyway, and now that we gave screen size stats
it's not really needed any more.

Fixes #136, the database after creating from scratch has the mobile
column as integer, whereas my production one has boolean. Not sure how
that happened, but not really worth fixing (so just remove).