### PR TITLE
Link to paths by allowing people to fill in domain

### DIFF
--- a/cron/cron_test.go
+++ b/cron/cron_test.go
@@ -43,7 +43,7 @@ func TestDataRetention(t *testing.T) {
 	}
 
 	out := fmt.Sprintf("%d %d %t %v %v", total, display, more, err, stats)
-	want := `2 2 false <nil> [{2 10 /a  <nil> [{2019-08-31 [0 0 0 0 0 0 0 0 0 0 0 0 0 0 2 0 0 0 0 0 0 0 0 0]}]}]`
+	want := `2 2 false <nil> [{2 10 /a false  <nil> [{2019-08-31 [0 0 0 0 0 0 0 0 0 0 0 0 0 0 2 0 0 0 0 0 0 0 0 0]}]}]`
 	if out != want {
 		t.Errorf("\ngot:  %s\nwant: %s", out, want)
 	}

--- a/cron/hit_stat_test.go
+++ b/cron/hit_stat_test.go
@@ -47,13 +47,13 @@ func TestHitStats(t *testing.T) {
 		t.Fatalf("len(stats) is not 2: %d", len(stats))
 	}
 
-	want0 := `{"Count":2,"Max":10,"Path":"/asd","Title":"aSd","RefScheme":null,"Stats":[{"Day":"2019-08-31","Days":[0,0,0,0,0,0,0,0,0,0,0,0,0,0,2,0,0,0,0,0,0,0,0,0]}]}`
+	want0 := `{"Count":2,"Max":10,"Path":"/asd","Event":false,"Title":"aSd","RefScheme":null,"Stats":[{"Day":"2019-08-31","Days":[0,0,0,0,0,0,0,0,0,0,0,0,0,0,2,0,0,0,0,0,0,0,0,0]}]}`
 	got0 := string(jsonutil.MustMarshal(stats[0]))
 	if got0 != want0 {
 		t.Errorf("first wrong\ngot:  %s\nwant: %s", got0, want0)
 	}
 
-	want1 := `{"Count":1,"Max":10,"Path":"/zxc","Title":"","RefScheme":null,"Stats":[{"Day":"2019-08-31","Days":[0,0,0,0,0,0,0,0,0,0,0,0,0,0,1,0,0,0,0,0,0,0,0,0]}]}`
+	want1 := `{"Count":1,"Max":10,"Path":"/zxc","Event":false,"Title":"","RefScheme":null,"Stats":[{"Day":"2019-08-31","Days":[0,0,0,0,0,0,0,0,0,0,0,0,0,0,1,0,0,0,0,0,0,0,0,0]}]}`
 	got1 := string(jsonutil.MustMarshal(stats[1]))
 	if got1 != want1 {
 		t.Errorf("second wrong\ngot:  %s\nwant: %s", got1, want1)

--- a/db/migrate/pgsql/2020-01-24-2-domain.sql
+++ b/db/migrate/pgsql/2020-01-24-2-domain.sql
@@ -1,0 +1,11 @@
+begin;
+	insert into updates (subject, created_at, show_at, body) values (
+		'New setting: domain (for linking)', now(), now(),
+		'<p>You can now fill in you site’s domain in the settings; this will allow linking the path directly from the overview.</p>');
+
+	alter table hits drop column domain;
+	alter table hits add column event int default 0;
+	alter table sites add column link_domain varchar not null default '';
+
+	insert into version values ('2020-01-24-2-domain');
+commit;

--- a/db/migrate/sqlite/2020-01-24-2-domain.sql
+++ b/db/migrate/sqlite/2020-01-24-2-domain.sql
@@ -1,0 +1,28 @@
+begin;
+	alter table sites add column link_domain varchar not null default '';
+
+	create table hits2 (
+		site           integer        not null                 check(site > 0),
+
+		path           varchar        not null,
+		ref            varchar        not null,
+		ref_original   varchar,
+		ref_params     varchar,
+		ref_scheme     varchar        null                     check(ref_scheme in ('h', 'g', 'o')),
+		browser        varchar        not null,
+		size           varchar        not null default '',
+		location       varchar        not null default '',
+		count_ref      varchar        not null default '',
+		bot            int            default 0,
+		title          varchar        not null default '',
+		event          int            default 0,
+
+		created_at     timestamp      not null                 check(created_at = strftime('%Y-%m-%d %H:%M:%S', created_at))
+	);
+
+	insert into hits2 select site, path, ref, ref_original, ref_params, ref_scheme, browser, size, location, count_ref, bot, title, 0, created_at from hits;
+	drop table hits;
+	alter table hits2 rename to hits;
+
+	insert into version values ('2020-01-24-2-domain');
+commit;

--- a/handlers/backend.go
+++ b/handlers/backend.go
@@ -631,10 +631,11 @@ func (h backend) saveSettings(w http.ResponseWriter, r *http.Request) error {
 	v := zvalidate.New()
 
 	args := struct {
-		Name     string                   `json:"name"`
-		Cname    string                   `json:"cname"`
-		Settings goatcounter.SiteSettings `json:"settings"`
-		User     goatcounter.User         `json:"user"`
+		Name       string                   `json:"name"`
+		Cname      string                   `json:"cname"`
+		LinkDomain string                   `json:"link_domain"`
+		Settings   goatcounter.SiteSettings `json:"settings"`
+		User       goatcounter.User         `json:"user"`
 	}{}
 	_, err := zhttp.Decode(r, &args)
 	if err != nil {
@@ -667,6 +668,7 @@ func (h backend) saveSettings(w http.ResponseWriter, r *http.Request) error {
 	site := goatcounter.MustGetSite(txctx)
 	site.Name = args.Name
 	site.Settings = args.Settings
+	site.LinkDomain = args.LinkDomain
 	if args.Cname != "" && !site.PlanCustomDomain(txctx) {
 		return guru.New(http.StatusForbidden, "need a business plan to set custom domain")
 	}

--- a/hit.go
+++ b/hit.go
@@ -39,6 +39,7 @@ type Hit struct {
 	Title       string            `db:"title" json:"t,omitempty"`
 	Domain      string            `db:"domain" json:"d,omitempty"`
 	Ref         string            `db:"ref" json:"r,omitempty"`
+	Event       bool              `db:"event" json:"e,omitempty"`
 	RefParams   *string           `db:"ref_params" json:"-"`
 	RefOriginal *string           `db:"ref_original" json:"-"`
 	RefScheme   *string           `db:"ref_scheme" json:"-"`
@@ -232,7 +233,9 @@ func (h *Hit) Defaults(ctx context.Context) {
 	}
 
 	h.Ref = strings.TrimRight(h.Ref, "/")
-	h.Path = "/" + strings.Trim(h.Path, "/")
+	if !h.Event {
+		h.Path = "/" + strings.Trim(h.Path, "/")
+	}
 }
 
 // Validate the object.
@@ -286,6 +289,7 @@ type HitStat struct {
 	Count     int     `db:"count"`
 	Max       int     `db:"-"`
 	Path      string  `db:"path"`
+	Event     bool    `db:"event"`
 	Title     string  `db:"title"`
 	RefScheme *string `db:"ref_scheme"`
 	Stats     []Stat

--- a/memstore.go
+++ b/memstore.go
@@ -49,7 +49,7 @@ func (m *ms) Persist(ctx context.Context) ([]Hit, error) {
 	ins := bulk.NewInsert(ctx, zdb.MustGet(ctx).(*sqlx.DB),
 		"hits", []string{"site", "path", "ref", "ref_params", "ref_original",
 			"ref_scheme", "browser", "size", "location", "created_at", "count_ref",
-			"bot", "title", "domain"})
+			"bot", "title"})
 	for i, h := range hits {
 		var err error
 		h.RefURL, err = url.Parse(h.Ref)
@@ -85,7 +85,7 @@ func (m *ms) Persist(ctx context.Context) ([]Hit, error) {
 
 		ins.Values(h.Site, h.Path, h.Ref, h.RefParams, h.RefOriginal,
 			h.RefScheme, h.Browser, h.Size, h.Location, h.CreatedAt.Format(zdb.Date),
-			countRef, h.Bot, h.Title, h.Domain)
+			countRef, h.Bot, h.Title)
 	}
 
 	return hits, ins.Finish()

--- a/pack/pack.go
+++ b/pack/pack.go
@@ -11987,6 +11987,7 @@ http://nicolasgallagher.com/micro-clearfix-hack/
 	};
 
 	// Highlight a filter pattern in the path and title.
+	// TODO: don't highlight "go" link.
 	var highlight_filter = function(s) {
 		if (s === '')
 			return;
@@ -12763,12 +12764,8 @@ form .err  { color: red; display: block; }
 
 
 /*** Pages list ***/
-.count-list td {
-	vertical-align: top;
-}
-.count-list td.generated {
-	font-style: italic;
-}
+.count-list td           { vertical-align: top; }
+.count-list td.generated { font-style: italic; }
 
 .count-list td:first-child {  /* Count */
 	text-align: right;
@@ -12787,15 +12784,13 @@ form .err  { color: red; display: block; }
 	word-break: break-all; /* don't make it wider for very long urls */
 }
 
+/* Otherwise .page-title has different vertical alignment? Hmmm... */
+.page-title, .rlink { display: inline-block; overflow: hidden; }
+
 /* Ideally I'd like the … to be in the centre, rather than at the end. Need JS
  * solution for that though :-/ */
-.page-title, .rlink {
-	display: inline-block; max-width: 17.5rem;
-	text-overflow: ellipsis; white-space: nowrap; overflow: hidden;
-}
-.rlink {
-	min-width: 3em;   /* Make very short paths (like just /) easier to click/touch. */
-}
+.rlink { max-width: 17.5rem; text-overflow: ellipsis; white-space: nowrap; }
+.rlink { min-width: 3em; } /* Make very short paths (like just /) easier to click/touch. */
 .page-title b, .rlink b { background-color: yellow; }
 
 .count-list tr {
@@ -13577,15 +13572,20 @@ var Templates = map[string][]byte{
 		<td>{{nformat2 $h.Count $.Site}}</td>
 		<td class="hide-mobile">
 			<a class="rlink" title="{{$h.Path}}" href="?showrefs={{$h.Path}}&period-start={{tformat $.PeriodStart ""}}&period-end={{tformat $.PeriodEnd ""}}#{{$h.Path}}">{{$h.Path}}</a><br>
-			<small class="page-title" title="{{$h.Title}}">{{if $h.Title}}{{$h.Title}}{{else}}<em>(no title)</em>{{end}}</small>
+			<small class="page-title" title="{{$h.Title}}">
+				{{if $h.Title}}{{$h.Title}}{{else}}<em>(no title)</em>{{end}}
+				{{if and $.Site.LinkDomain (not $h.Event)}}<sup><a class="go" target="_blank" rel="noopener" href="https://{{$.Site.LinkDomain}}{{$h.Path}}">go</a></sup>{{end}}
+			</small>
 		</td>
 		<td>
 			<div class="show-mobile">
 				<a class="rlink" href="?showrefs={{$h.Path}}&period-start={{tformat $.PeriodStart ""}}&period-end={{tformat $.PeriodEnd ""}}#{{$h.Path}}">{{$h.Path}}</a>
-				<small class="page-title" title="{{$h.Title}}">| {{if $h.Title}}{{$h.Title}}{{else}}<em>(no title)</em>{{end}}</small>
+				<small class="page-title" title="{{$h.Title}}">|
+					{{if $h.Title}}{{$h.Title}}{{else}}<em>(no title)</em>{{end}}
+					{{if and $.Site.LinkDomain (not $h.Event)}}<sup><a class="go" target="_blank" rel="noopener" href="https://{{$.Site.LinkDomain}}{{$h.Path}}">go</a></sup>{{end}}
+				</small>
 			</div>
 			<div class="chart chart-bar">
-				{{if and $.Site.LinkDomain (not $h.Event)}}<a class="top go" target="_blank" rel="noopener" href="https://{{$.Site.LinkDomain}}{{$h.Path}}">go</a>{{end}}
 				<span class="top max" title="Y-axis scale">{{nformat2 .Max $.Site}}</span>
 				<span class="half"></span>
 				{{bar_chart $.Context .Stats .Max}}

--- a/pack/pack.go
+++ b/pack/pack.go
@@ -14140,7 +14140,7 @@ parameters:</p>
 				<label for="link_domain">Domain</label>
 				<input type="text" name="link_domain" id="link_domain" value="{{.Site.LinkDomain}}">
 				{{validate "site.link_domain" .Validate}}
-				<span>Your site’s domain, e.g. <em>“www.example.com”</em>, used only for linking.</span>
+				<span>Your site’s domain, e.g. <em>“www.example.com”</em>, used for linking to the page in the overview.</span>
 
 				<label for="code">Code</label>
 				<input type="text" {{/*name="code"*/}} disabled id="code" value="{{.Site.Code}}">

--- a/pack/pack.go
+++ b/pack/pack.go
@@ -507,6 +507,18 @@ commit;
 commit;
 
 `),
+	"db/migrate/pgsql/2020-01-24-2-domain.sql": []byte(`begin;
+	insert into updates (subject, created_at, show_at, body) values (
+		'New setting: domain (for linking)', now(), now(),
+		'<p>You can now fill in you site’s domain in the settings; this will allow linking the path directly from the overview.</p>');
+
+	alter table hits drop column domain;
+	alter table hits add column event int default 0;
+	alter table sites add column link_domain varchar not null default '';
+
+	insert into version values ('2020-01-24-2-domain');
+commit;
+`),
 }
 
 var MigrationsSQLite = map[string][]byte{
@@ -1050,6 +1062,35 @@ commit;
 commit;
 
 `),
+	"db/migrate/sqlite/2020-01-24-2-domain.sql": []byte(`begin;
+	alter table sites add column link_domain varchar not null default '';
+
+	create table hits2 (
+		site           integer        not null                 check(site > 0),
+
+		path           varchar        not null,
+		ref            varchar        not null,
+		ref_original   varchar,
+		ref_params     varchar,
+		ref_scheme     varchar        null                     check(ref_scheme in ('h', 'g', 'o')),
+		browser        varchar        not null,
+		size           varchar        not null default '',
+		location       varchar        not null default '',
+		count_ref      varchar        not null default '',
+		bot            int            default 0,
+		title          varchar        not null default '',
+		event          int            default 0,
+
+		created_at     timestamp      not null                 check(created_at = strftime('%Y-%m-%d %H:%M:%S', created_at))
+	);
+
+	insert into hits2 select site, path, ref, ref_original, ref_params, ref_scheme, browser, size, location, count_ref, bot, title, 0, created_at from hits;
+	drop table hits;
+	alter table hits2 rename to hits;
+
+	insert into version values ('2020-01-24-2-domain');
+commit;
+`),
 }
 
 var Public = map[string][]byte{
@@ -1502,7 +1543,7 @@ h1 a:after, h2 a:after, h3 a:after, h4 a:after, h5 a:after, h6 a:after {
 // v1.2, which can be found in the LICENSE file or at http://eupl12.zgo.at
 
 // See /bin/proxy on how to test this locally.
-(function() { 
+(function() {
 	'use strict';
 
 	var VARS = {};
@@ -1517,20 +1558,17 @@ h1 a:after, h2 a:after, h3 a:after, h4 a:after, h5 a:after, h6 a:after {
 			p: count_vars.path     || VARS.path,
 			r: count_vars.referrer || VARS.referrer,
 			t: count_vars.title    || VARS.title,
-			d: count_vars.domain   || VARS.domain,
 		};
 
 		// Save callbacks.
 		var rcb, pcb, tcb, dcb;
 		if (typeof(results.r) === 'function') rcb = results.r;
 		if (typeof(results.t) === 'function') tcb = results.t;
-		if (typeof(results.d) === 'function') dcb = results.d;
 		if (typeof(results.p) === 'function') pcb = results.p;
 
 		// Get the values unless explicitly given.
 		if (is_empty(results.r)) results.r = document.referrer;
 		if (is_empty(results.t)) results.t = document.title;
-		if (is_empty(results.d)) results.d = location.hostname;
 		if (is_empty(results.p)) {
 			var loc = location,
 				c = document.querySelector('link[rel="canonical"][href]');
@@ -1546,7 +1584,6 @@ h1 a:after, h2 a:after, h3 a:after, h4 a:after, h5 a:after, h6 a:after {
 		// Apply callbacks.
 		if (rcb) results.r = rcb(results.r);
 		if (tcb) results.t = tcb(results.t);
-		if (tcb) results.d = tcb(results.d);
 		if (pcb) results.p = pcb(results.p);
 
 		return results;
@@ -1597,11 +1634,11 @@ h1 a:after, h2 a:after, h3 a:after, h4 a:after, h5 a:after, h6 a:after {
 		setTimeout(function() {
 			if (!img.parentNode)
 				return;
-			img.src = ''; 
+			img.src = '';
 			document.body.removeChild(img)
 		}, 3000);
 
-		document.body.appendChild(img);  
+		document.body.appendChild(img);
 	};
 
 	// Expose public API.
@@ -1622,7 +1659,7 @@ h1 a:after, h2 a:after, h3 a:after, h4 a:after, h5 a:after, h6 a:after {
 // v1.2, which can be found in the LICENSE file or at http://eupl12.zgo.at
 
 // See /bin/proxy on how to test this locally.
-(function() { 
+(function() {
 	'use strict';
 
 	var VARS = {};
@@ -1637,20 +1674,17 @@ h1 a:after, h2 a:after, h3 a:after, h4 a:after, h5 a:after, h6 a:after {
 			p: count_vars.path     || VARS.path,
 			r: count_vars.referrer || VARS.referrer,
 			t: count_vars.title    || VARS.title,
-			d: count_vars.domain   || VARS.domain,
 		};
 
 		// Save callbacks.
 		var rcb, pcb, tcb, dcb;
 		if (typeof(results.r) === 'function') rcb = results.r;
 		if (typeof(results.t) === 'function') tcb = results.t;
-		if (typeof(results.d) === 'function') dcb = results.d;
 		if (typeof(results.p) === 'function') pcb = results.p;
 
 		// Get the values unless explicitly given.
 		if (is_empty(results.r)) results.r = document.referrer;
 		if (is_empty(results.t)) results.t = document.title;
-		if (is_empty(results.d)) results.d = location.hostname;
 		if (is_empty(results.p)) {
 			var loc = location,
 				c = document.querySelector('link[rel="canonical"][href]');
@@ -1666,7 +1700,6 @@ h1 a:after, h2 a:after, h3 a:after, h4 a:after, h5 a:after, h6 a:after {
 		// Apply callbacks.
 		if (rcb) results.r = rcb(results.r);
 		if (tcb) results.t = tcb(results.t);
-		if (tcb) results.d = tcb(results.d);
 		if (pcb) results.p = pcb(results.p);
 
 		return results;
@@ -1717,11 +1750,11 @@ h1 a:after, h2 a:after, h3 a:after, h4 a:after, h5 a:after, h6 a:after {
 		setTimeout(function() {
 			if (!img.parentNode)
 				return;
-			img.src = ''; 
+			img.src = '';
 			document.body.removeChild(img)
 		}, 3000);
 
-		document.body.appendChild(img);  
+		document.body.appendChild(img);
 	};
 
 	// Expose public API.
@@ -13552,9 +13585,7 @@ var Templates = map[string][]byte{
 				<small class="page-title" title="{{$h.Title}}">| {{if $h.Title}}{{$h.Title}}{{else}}<em>(no title)</em>{{end}}</small>
 			</div>
 			<div class="chart chart-bar">
-				{{/* We don't have the site domain, so can't link to it.
-				<a class="top go" target="_blank" rel="noopener" href="https://{{$.Site.Name}}{{$h.Path}}">go</a>
-				*/}}
+				{{if and $.Site.LinkDomain (not $h.Event)}}<a class="top go" target="_blank" rel="noopener" href="https://{{$.Site.LinkDomain}}{{$h.Path}}">go</a>{{end}}
 				<span class="top max" title="Y-axis scale">{{nformat2 .Max $.Site}}</span>
 				<span class="half"></span>
 				{{bar_chart $.Context .Stats .Max}}
@@ -13627,8 +13658,8 @@ return value is sent to the server. Nothing is sent if the return value from the
 	<li><code>title</code> – Page title. The UI will always display the latest
 		title used. Default is <code>document.title</code>.</li>
 
-	<li><code>domain</code> – Domain; not yet used. Default is
-		<code>window.location.hostname</code>.</li>
+	<li><code>event</code> – Treat the <code>path</code> as an event, rather
+		than a URL. Boolean.</li>
 
 	<li><code>referrer</code> – Where the user came from; can be an URL
 		(<code>https://example.com</code>) or any string
@@ -14105,6 +14136,11 @@ parameters:</p>
 				<input type="text" name="name" id="name" value="{{.Site.Name}}">
 				{{validate "site.name" .Validate}}
 				<span>Your site’s name, e.g. <em>“example.com”</em> or <em>“Example Inc”</em>.</span>
+
+				<label for="link_domain">Domain</label>
+				<input type="text" name="link_domain" id="link_domain" value="{{.Site.LinkDomain}}">
+				{{validate "site.link_domain" .Validate}}
+				<span>Your site’s domain, e.g. <em>“www.example.com”</em>, used only for linking.</span>
 
 				<label for="code">Code</label>
 				<input type="text" {{/*name="code"*/}} disabled id="code" value="{{.Site.Code}}">

--- a/pack/pack.go
+++ b/pack/pack.go
@@ -11939,6 +11939,12 @@ http://nicolasgallagher.com/micro-clearfix-hack/
 				});
 			}, 300);
 		});
+
+		// Don't submit form on enter.
+		$('#filter-paths').on('keydown', function(e) {
+			if (e.keyCode === 13)
+				e.preventDefault();
+		})
 	};
 
 	// Paginate the main path overview.
@@ -11987,7 +11993,6 @@ http://nicolasgallagher.com/micro-clearfix-hack/
 	};
 
 	// Highlight a filter pattern in the path and title.
-	// TODO: don't highlight "go" link.
 	var highlight_filter = function(s) {
 		if (s === '')
 			return;
@@ -12785,11 +12790,13 @@ form .err  { color: red; display: block; }
 }
 
 /* Otherwise .page-title has different vertical alignment? Hmmm... */
-.page-title, .rlink { display: inline-block; overflow: hidden; }
+.show-mobile .page-title { vertical-align: top; }
+.show-mobile .page-title+sup { bottom: 2.5ex; }
 
 /* Ideally I'd like the … to be in the centre, rather than at the end. Need JS
  * solution for that though :-/ */
-.rlink { max-width: 17.5rem; text-overflow: ellipsis; white-space: nowrap; }
+.rlink { display: inline-block; overflow: hidden;
+         max-width: 17.5rem; text-overflow: ellipsis; white-space: nowrap; }
 .rlink { min-width: 3em; } /* Make very short paths (like just /) easier to click/touch. */
 .page-title b, .rlink b { background-color: yellow; }
 
@@ -13572,18 +13579,14 @@ var Templates = map[string][]byte{
 		<td>{{nformat2 $h.Count $.Site}}</td>
 		<td class="hide-mobile">
 			<a class="rlink" title="{{$h.Path}}" href="?showrefs={{$h.Path}}&period-start={{tformat $.PeriodStart ""}}&period-end={{tformat $.PeriodEnd ""}}#{{$h.Path}}">{{$h.Path}}</a><br>
-			<small class="page-title" title="{{$h.Title}}">
-				{{if $h.Title}}{{$h.Title}}{{else}}<em>(no title)</em>{{end}}
-				{{if and $.Site.LinkDomain (not $h.Event)}}<sup><a class="go" target="_blank" rel="noopener" href="https://{{$.Site.LinkDomain}}{{$h.Path}}">go</a></sup>{{end}}
-			</small>
+			<small class="page-title" title="{{$h.Title}}">{{if $h.Title}}{{$h.Title}}{{else}}<em>(no title)</em>{{end}}</small>
+			{{if and $.Site.LinkDomain (not $h.Event)}}<sup><a class="go" target="_blank" rel="noopener" href="https://{{$.Site.LinkDomain}}{{$h.Path}}">go</a></sup>{{end}}
 		</td>
 		<td>
 			<div class="show-mobile">
 				<a class="rlink" href="?showrefs={{$h.Path}}&period-start={{tformat $.PeriodStart ""}}&period-end={{tformat $.PeriodEnd ""}}#{{$h.Path}}">{{$h.Path}}</a>
-				<small class="page-title" title="{{$h.Title}}">|
-					{{if $h.Title}}{{$h.Title}}{{else}}<em>(no title)</em>{{end}}
-					{{if and $.Site.LinkDomain (not $h.Event)}}<sup><a class="go" target="_blank" rel="noopener" href="https://{{$.Site.LinkDomain}}{{$h.Path}}">go</a></sup>{{end}}
-				</small>
+				<small class="page-title" title="{{$h.Title}}">| {{if $h.Title}}{{$h.Title}}{{else}}<em>(no title)</em>{{end}}</small>
+				{{if and $.Site.LinkDomain (not $h.Event)}}<sup><a class="go" target="_blank" rel="noopener" href="https://{{$.Site.LinkDomain}}{{$h.Path}}">go</a></sup>{{end}}
 			</div>
 			<div class="chart chart-bar">
 				<span class="top max" title="Y-axis scale">{{nformat2 .Max $.Site}}</span>

--- a/public/count.js
+++ b/public/count.js
@@ -3,7 +3,7 @@
 // v1.2, which can be found in the LICENSE file or at http://eupl12.zgo.at
 
 // See /bin/proxy on how to test this locally.
-(function() { 
+(function() {
 	'use strict';
 
 	var VARS = {};
@@ -18,20 +18,17 @@
 			p: count_vars.path     || VARS.path,
 			r: count_vars.referrer || VARS.referrer,
 			t: count_vars.title    || VARS.title,
-			d: count_vars.domain   || VARS.domain,
 		};
 
 		// Save callbacks.
 		var rcb, pcb, tcb, dcb;
 		if (typeof(results.r) === 'function') rcb = results.r;
 		if (typeof(results.t) === 'function') tcb = results.t;
-		if (typeof(results.d) === 'function') dcb = results.d;
 		if (typeof(results.p) === 'function') pcb = results.p;
 
 		// Get the values unless explicitly given.
 		if (is_empty(results.r)) results.r = document.referrer;
 		if (is_empty(results.t)) results.t = document.title;
-		if (is_empty(results.d)) results.d = location.hostname;
 		if (is_empty(results.p)) {
 			var loc = location,
 				c = document.querySelector('link[rel="canonical"][href]');
@@ -47,7 +44,6 @@
 		// Apply callbacks.
 		if (rcb) results.r = rcb(results.r);
 		if (tcb) results.t = tcb(results.t);
-		if (tcb) results.d = tcb(results.d);
 		if (pcb) results.p = pcb(results.p);
 
 		return results;
@@ -98,11 +94,11 @@
 		setTimeout(function() {
 			if (!img.parentNode)
 				return;
-			img.src = ''; 
+			img.src = '';
 			document.body.removeChild(img)
 		}, 3000);
 
-		document.body.appendChild(img);  
+		document.body.appendChild(img);
 	};
 
 	// Expose public API.

--- a/public/count.min.js
+++ b/public/count.min.js
@@ -3,7 +3,7 @@
 // v1.2, which can be found in the LICENSE file or at http://eupl12.zgo.at
 
 // See /bin/proxy on how to test this locally.
-(function() { 
+(function() {
 	'use strict';
 
 	var VARS = {};
@@ -18,20 +18,17 @@
 			p: count_vars.path     || VARS.path,
 			r: count_vars.referrer || VARS.referrer,
 			t: count_vars.title    || VARS.title,
-			d: count_vars.domain   || VARS.domain,
 		};
 
 		// Save callbacks.
 		var rcb, pcb, tcb, dcb;
 		if (typeof(results.r) === 'function') rcb = results.r;
 		if (typeof(results.t) === 'function') tcb = results.t;
-		if (typeof(results.d) === 'function') dcb = results.d;
 		if (typeof(results.p) === 'function') pcb = results.p;
 
 		// Get the values unless explicitly given.
 		if (is_empty(results.r)) results.r = document.referrer;
 		if (is_empty(results.t)) results.t = document.title;
-		if (is_empty(results.d)) results.d = location.hostname;
 		if (is_empty(results.p)) {
 			var loc = location,
 				c = document.querySelector('link[rel="canonical"][href]');
@@ -47,7 +44,6 @@
 		// Apply callbacks.
 		if (rcb) results.r = rcb(results.r);
 		if (tcb) results.t = tcb(results.t);
-		if (tcb) results.d = tcb(results.d);
 		if (pcb) results.p = pcb(results.p);
 
 		return results;
@@ -98,11 +94,11 @@
 		setTimeout(function() {
 			if (!img.parentNode)
 				return;
-			img.src = ''; 
+			img.src = '';
 			document.body.removeChild(img)
 		}, 3000);
 
-		document.body.appendChild(img);  
+		document.body.appendChild(img);
 	};
 
 	// Expose public API.

--- a/public/script_backend.js
+++ b/public/script_backend.js
@@ -48,6 +48,12 @@
 				});
 			}, 300);
 		});
+
+		// Don't submit form on enter.
+		$('#filter-paths').on('keydown', function(e) {
+			if (e.keyCode === 13)
+				e.preventDefault();
+		})
 	};
 
 	// Paginate the main path overview.
@@ -96,7 +102,6 @@
 	};
 
 	// Highlight a filter pattern in the path and title.
-	// TODO: don't highlight "go" link.
 	var highlight_filter = function(s) {
 		if (s === '')
 			return;

--- a/public/script_backend.js
+++ b/public/script_backend.js
@@ -96,6 +96,7 @@
 	};
 
 	// Highlight a filter pattern in the path and title.
+	// TODO: don't highlight "go" link.
 	var highlight_filter = function(s) {
 		if (s === '')
 			return;

--- a/public/style_backend.css
+++ b/public/style_backend.css
@@ -65,12 +65,8 @@ form .err  { color: red; display: block; }
 
 
 /*** Pages list ***/
-.count-list td {
-	vertical-align: top;
-}
-.count-list td.generated {
-	font-style: italic;
-}
+.count-list td           { vertical-align: top; }
+.count-list td.generated { font-style: italic; }
 
 .count-list td:first-child {  /* Count */
 	text-align: right;

--- a/public/style_backend.css
+++ b/public/style_backend.css
@@ -86,11 +86,13 @@ form .err  { color: red; display: block; }
 }
 
 /* Otherwise .page-title has different vertical alignment? Hmmm... */
-.page-title, .rlink { display: inline-block; overflow: hidden; }
+.show-mobile .page-title { vertical-align: top; }
+.show-mobile .page-title+sup { bottom: 2.5ex; }
 
 /* Ideally I'd like the … to be in the centre, rather than at the end. Need JS
  * solution for that though :-/ */
-.rlink { max-width: 17.5rem; text-overflow: ellipsis; white-space: nowrap; }
+.rlink { display: inline-block; overflow: hidden;
+         max-width: 17.5rem; text-overflow: ellipsis; white-space: nowrap; }
 .rlink { min-width: 3em; } /* Make very short paths (like just /) easier to click/touch. */
 .page-title b, .rlink b { background-color: yellow; }
 

--- a/public/style_backend.css
+++ b/public/style_backend.css
@@ -85,15 +85,13 @@ form .err  { color: red; display: block; }
 	word-break: break-all; /* don't make it wider for very long urls */
 }
 
+/* Otherwise .page-title has different vertical alignment? Hmmm... */
+.page-title, .rlink { display: inline-block; overflow: hidden; }
+
 /* Ideally I'd like the … to be in the centre, rather than at the end. Need JS
  * solution for that though :-/ */
-.page-title, .rlink {
-	display: inline-block; max-width: 17.5rem;
-	text-overflow: ellipsis; white-space: nowrap; overflow: hidden;
-}
-.rlink {
-	min-width: 3em;   /* Make very short paths (like just /) easier to click/touch. */
-}
+.rlink { max-width: 17.5rem; text-overflow: ellipsis; white-space: nowrap; }
+.rlink { min-width: 3em; } /* Make very short paths (like just /) easier to click/touch. */
 .page-title b, .rlink b { background-color: yellow; }
 
 .count-list tr {

--- a/site.go
+++ b/site.go
@@ -45,9 +45,10 @@ type Site struct {
 	ID     int64  `db:"id"`
 	Parent *int64 `db:"parent"`
 
-	Name         string       `db:"name"`  // Any name for the website.
-	Cname        *string      `db:"cname"` // Custom domain, e.g. "stats.example.com"
-	Code         string       `db:"code"`  // Domain code (arp242, which makes arp242.goatcounter.com)
+	Name         string       `db:"name"`        // Any name for the website.
+	Cname        *string      `db:"cname"`       // Custom domain, e.g. "stats.example.com"
+	Code         string       `db:"code"`        // Domain code (arp242, which makes arp242.goatcounter.com)
+	LinkDomain   string       `db:"link_domain"` // Site domain for linking (www.arp242.net).
 	Plan         string       `db:"plan"`
 	Stripe       *string      `db:"stripe"`
 	Settings     SiteSettings `db:"settings"`
@@ -137,6 +138,7 @@ func (s *Site) Validate(ctx context.Context) error {
 		v.Range("settings.data_retention", int64(s.Settings.DataRetention), 14, 0)
 	}
 
+	v.Domain("link_domain", s.LinkDomain)
 	v.Len("code", s.Code, 1, 50)
 	v.Len("name", s.Name, 4, 255)
 	v.Exclude("code", s.Code, reserved)

--- a/site.go
+++ b/site.go
@@ -225,8 +225,8 @@ func (s *Site) Update(ctx context.Context) error {
 	}
 
 	_, err = zdb.MustGet(ctx).ExecContext(ctx,
-		`update sites set name=$1, settings=$2, cname=$3, updated_at=$4 where id=$5`,
-		s.Name, s.Settings, s.Cname, s.UpdatedAt.Format(zdb.Date), s.ID)
+		`update sites set name=$1, settings=$2, cname=$3, link_domain=$4, updated_at=$5 where id=$6`,
+		s.Name, s.Settings, s.Cname, s.LinkDomain, s.UpdatedAt.Format(zdb.Date), s.ID)
 	return errors.Wrap(err, "Site.Update")
 }
 

--- a/test.go
+++ b/test.go
@@ -50,11 +50,12 @@ func StartTest(t *testing.T) (context.Context, func()) {
 	}
 
 	if schema == "" {
-		schema, err := ioutil.ReadFile(top + "/db/schema.sql")
+		s, err := ioutil.ReadFile(top + "/db/schema.sql")
 		if err != nil {
 			t.Fatal(err)
 		}
-		_, err = db.Exec(string(schema))
+		schema = string(s)
+		_, err = db.Exec(schema)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -79,6 +80,11 @@ func StartTest(t *testing.T) (context.Context, func()) {
 				t.Fatalf("read migration: %s", err)
 			}
 			migrations = append(migrations, string(mb))
+		}
+	} else {
+		_, err = db.Exec(schema)
+		if err != nil {
+			t.Fatal(err)
 		}
 	}
 

--- a/tpl/_backend_pages.gohtml
+++ b/tpl/_backend_pages.gohtml
@@ -3,18 +3,14 @@
 		<td>{{nformat2 $h.Count $.Site}}</td>
 		<td class="hide-mobile">
 			<a class="rlink" title="{{$h.Path}}" href="?showrefs={{$h.Path}}&period-start={{tformat $.PeriodStart ""}}&period-end={{tformat $.PeriodEnd ""}}#{{$h.Path}}">{{$h.Path}}</a><br>
-			<small class="page-title" title="{{$h.Title}}">
-				{{if $h.Title}}{{$h.Title}}{{else}}<em>(no title)</em>{{end}}
-				{{if and $.Site.LinkDomain (not $h.Event)}}<sup><a class="go" target="_blank" rel="noopener" href="https://{{$.Site.LinkDomain}}{{$h.Path}}">go</a></sup>{{end}}
-			</small>
+			<small class="page-title" title="{{$h.Title}}">{{if $h.Title}}{{$h.Title}}{{else}}<em>(no title)</em>{{end}}</small>
+			{{if and $.Site.LinkDomain (not $h.Event)}}<sup><a class="go" target="_blank" rel="noopener" href="https://{{$.Site.LinkDomain}}{{$h.Path}}">go</a></sup>{{end}}
 		</td>
 		<td>
 			<div class="show-mobile">
 				<a class="rlink" href="?showrefs={{$h.Path}}&period-start={{tformat $.PeriodStart ""}}&period-end={{tformat $.PeriodEnd ""}}#{{$h.Path}}">{{$h.Path}}</a>
-				<small class="page-title" title="{{$h.Title}}">|
-					{{if $h.Title}}{{$h.Title}}{{else}}<em>(no title)</em>{{end}}
-					{{if and $.Site.LinkDomain (not $h.Event)}}<sup><a class="go" target="_blank" rel="noopener" href="https://{{$.Site.LinkDomain}}{{$h.Path}}">go</a></sup>{{end}}
-				</small>
+				<small class="page-title" title="{{$h.Title}}">| {{if $h.Title}}{{$h.Title}}{{else}}<em>(no title)</em>{{end}}</small>
+				{{if and $.Site.LinkDomain (not $h.Event)}}<sup><a class="go" target="_blank" rel="noopener" href="https://{{$.Site.LinkDomain}}{{$h.Path}}">go</a></sup>{{end}}
 			</div>
 			<div class="chart chart-bar">
 				<span class="top max" title="Y-axis scale">{{nformat2 .Max $.Site}}</span>

--- a/tpl/_backend_pages.gohtml
+++ b/tpl/_backend_pages.gohtml
@@ -11,9 +11,7 @@
 				<small class="page-title" title="{{$h.Title}}">| {{if $h.Title}}{{$h.Title}}{{else}}<em>(no title)</em>{{end}}</small>
 			</div>
 			<div class="chart chart-bar">
-				{{/* We don't have the site domain, so can't link to it.
-				<a class="top go" target="_blank" rel="noopener" href="https://{{$.Site.Name}}{{$h.Path}}">go</a>
-				*/}}
+				{{if and $.Site.LinkDomain (not $h.Event)}}<a class="top go" target="_blank" rel="noopener" href="https://{{$.Site.LinkDomain}}{{$h.Path}}">go</a>{{end}}
 				<span class="top max" title="Y-axis scale">{{nformat2 .Max $.Site}}</span>
 				<span class="half"></span>
 				{{bar_chart $.Context .Stats .Max}}

--- a/tpl/_backend_pages.gohtml
+++ b/tpl/_backend_pages.gohtml
@@ -3,15 +3,21 @@
 		<td>{{nformat2 $h.Count $.Site}}</td>
 		<td class="hide-mobile">
 			<a class="rlink" title="{{$h.Path}}" href="?showrefs={{$h.Path}}&period-start={{tformat $.PeriodStart ""}}&period-end={{tformat $.PeriodEnd ""}}#{{$h.Path}}">{{$h.Path}}</a><br>
-			<small class="page-title" title="{{$h.Title}}">{{if $h.Title}}{{$h.Title}}{{else}}<em>(no title)</em>{{end}}</small>
+			<small class="page-title" title="{{$h.Title}}">
+				{{if $h.Title}}{{$h.Title}}{{else}}<em>(no title)</em>{{end}}
+				{{/* TODO: doesn't show if title ellided */}}
+				{{if and $.Site.LinkDomain (not $h.Event)}}<sup><a class="go" target="_blank" rel="noopener" href="https://{{$.Site.LinkDomain}}{{$h.Path}}">go</a></sup>{{end}}
+			</small>
 		</td>
 		<td>
 			<div class="show-mobile">
 				<a class="rlink" href="?showrefs={{$h.Path}}&period-start={{tformat $.PeriodStart ""}}&period-end={{tformat $.PeriodEnd ""}}#{{$h.Path}}">{{$h.Path}}</a>
-				<small class="page-title" title="{{$h.Title}}">| {{if $h.Title}}{{$h.Title}}{{else}}<em>(no title)</em>{{end}}</small>
+				<small class="page-title" title="{{$h.Title}}">|
+					{{if $h.Title}}{{$h.Title}}{{else}}<em>(no title)</em>{{end}}
+					{{if and $.Site.LinkDomain (not $h.Event)}}<sup><a class="go" target="_blank" rel="noopener" href="https://{{$.Site.LinkDomain}}{{$h.Path}}">go</a></sup>{{end}}
+				</small>
 			</div>
 			<div class="chart chart-bar">
-				{{if and $.Site.LinkDomain (not $h.Event)}}<a class="top go" target="_blank" rel="noopener" href="https://{{$.Site.LinkDomain}}{{$h.Path}}">go</a>{{end}}
 				<span class="top max" title="Y-axis scale">{{nformat2 .Max $.Site}}</span>
 				<span class="half"></span>
 				{{bar_chart $.Context .Stats .Max}}

--- a/tpl/_backend_pages.gohtml
+++ b/tpl/_backend_pages.gohtml
@@ -5,7 +5,6 @@
 			<a class="rlink" title="{{$h.Path}}" href="?showrefs={{$h.Path}}&period-start={{tformat $.PeriodStart ""}}&period-end={{tformat $.PeriodEnd ""}}#{{$h.Path}}">{{$h.Path}}</a><br>
 			<small class="page-title" title="{{$h.Title}}">
 				{{if $h.Title}}{{$h.Title}}{{else}}<em>(no title)</em>{{end}}
-				{{/* TODO: doesn't show if title ellided */}}
 				{{if and $.Site.LinkDomain (not $h.Event)}}<sup><a class="go" target="_blank" rel="noopener" href="https://{{$.Site.LinkDomain}}{{$h.Path}}">go</a></sup>{{end}}
 			</small>
 		</td>

--- a/tpl/_backend_sitecode.gohtml
+++ b/tpl/_backend_sitecode.gohtml
@@ -37,8 +37,8 @@ return value is sent to the server. Nothing is sent if the return value from the
 	<li><code>title</code> – Page title. The UI will always display the latest
 		title used. Default is <code>document.title</code>.</li>
 
-	<li><code>domain</code> – Domain; not yet used. Default is
-		<code>window.location.hostname</code>.</li>
+	<li><code>event</code> – Treat the <code>path</code> as an event, rather
+		than a URL. Boolean.</li>
 
 	<li><code>referrer</code> – Where the user came from; can be an URL
 		(<code>https://example.com</code>) or any string

--- a/tpl/backend_settings.gohtml
+++ b/tpl/backend_settings.gohtml
@@ -18,7 +18,7 @@
 				<label for="link_domain">Domain</label>
 				<input type="text" name="link_domain" id="link_domain" value="{{.Site.LinkDomain}}">
 				{{validate "site.link_domain" .Validate}}
-				<span>Your site’s domain, e.g. <em>“www.example.com”</em>, used only for linking.</span>
+				<span>Your site’s domain, e.g. <em>“www.example.com”</em>, used for linking to the page in the overview.</span>
 
 				<label for="code">Code</label>
 				<input type="text" {{/*name="code"*/}} disabled id="code" value="{{.Site.Code}}">

--- a/tpl/backend_settings.gohtml
+++ b/tpl/backend_settings.gohtml
@@ -15,6 +15,11 @@
 				{{validate "site.name" .Validate}}
 				<span>Your site’s name, e.g. <em>“example.com”</em> or <em>“Example Inc”</em>.</span>
 
+				<label for="link_domain">Domain</label>
+				<input type="text" name="link_domain" id="link_domain" value="{{.Site.LinkDomain}}">
+				{{validate "site.link_domain" .Validate}}
+				<span>Your site’s domain, e.g. <em>“www.example.com”</em>, used only for linking.</span>
+
 				<label for="code">Code</label>
 				<input type="text" {{/*name="code"*/}} disabled id="code" value="{{.Site.Code}}">
 				{{validate "site.code" .Validate}}


### PR DESCRIPTION
Remove hits.domain, as most people use GoatCounter from just one domain,
so just use a global domain default.

There are some cases where this isn't the case and people use it from
different subdomains, but I'm not sure if there's an easy way to support
that in the current UI: to get paths to show up individually you need to
frob with the paths anyway, so they won't be accurate.

I'm not sure if there are a lot of people using it like this, thus far
only one, and they had to hack with Google Analytics as well.

Can always revisit based on feedback/requests, instead of adding
something complex that (almost) no one uses/needs anyway.

Additionally, we also need to separate out "paths" and "events" for
this, as we can't link to events. I'll document/implement better support
for this later, before the 1.1 release.