### PR TITLE
Fixed small typo, now sample code works as expected

### DIFF
--- a/pack/pack.go
+++ b/pack/pack.go
@@ -13855,7 +13855,7 @@ own browser:</p>
 <pre>&lt;script&gt;
 	if (window.location.hash === '#skipgc')
 		localStorage.setItem('skipgc', 't');
-	if (localstorage.getItem('skipgc') === 't')
+	if (localStorage.getItem('skipgc') === 't')
 		window.goatcounter = {no_onload: true};
 &lt;/script&gt;
 {{template "code" .}}</pre>

--- a/tpl/_backend_sitecode.gohtml
+++ b/tpl/_backend_sitecode.gohtml
@@ -78,7 +78,7 @@ own browser:</p>
 <pre>&lt;script&gt;
 	if (window.location.hash === '#skipgc')
 		localStorage.setItem('skipgc', 't');
-	if (localstorage.getItem('skipgc') === 't')
+	if (localStorage.getItem('skipgc') === 't')
 		window.goatcounter = {no_onload: true};
 &lt;/script&gt;
 {{template "code" .}}</pre>


### PR DESCRIPTION
I was getting an error in Safari desktop because I copied the sample code you provide. Fixing the typo got rid of the error.