### PR TITLE
Fix thousands separator example for .

### DIFF
--- a/pack/pack.go
+++ b/pack/pack.go
@@ -14534,7 +14534,7 @@ parent site includes the child sites.</p>
 					<option {{option_value (string .Site.Settings.NumberFormat) "8239"}}>Thin space (42 123)</option>
 					<option {{option_value (string .Site.Settings.NumberFormat) "160"}}>Space (42 123)</option>
 					<option {{option_value (string .Site.Settings.NumberFormat) "44"}}>Comma (42,123)</option>
-					<option {{option_value (string .Site.Settings.NumberFormat) "46"}}>Dot (42.1234)</option>
+					<option {{option_value (string .Site.Settings.NumberFormat) "46"}}>Dot (42.123)</option>
 					<option {{option_value (string .Site.Settings.NumberFormat) "39"}}>Apostrophe (42'123)</option>
 					<option {{option_value (string .Site.Settings.NumberFormat) "1"}}>None (42123)</option>
 				</select>

--- a/tpl/backend_settings.gohtml
+++ b/tpl/backend_settings.gohtml
@@ -83,7 +83,7 @@
 					<option {{option_value (string .Site.Settings.NumberFormat) "8239"}}>Thin space (42 123)</option>
 					<option {{option_value (string .Site.Settings.NumberFormat) "160"}}>Space (42 123)</option>
 					<option {{option_value (string .Site.Settings.NumberFormat) "44"}}>Comma (42,123)</option>
-					<option {{option_value (string .Site.Settings.NumberFormat) "46"}}>Dot (42.1234)</option>
+					<option {{option_value (string .Site.Settings.NumberFormat) "46"}}>Dot (42.123)</option>
 					<option {{option_value (string .Site.Settings.NumberFormat) "39"}}>Apostrophe (42'123)</option>
 					<option {{option_value (string .Site.Settings.NumberFormat) "1"}}>None (42123)</option>
 				</select>


### PR DESCRIPTION
The current value has 4 numbers on the thousands part.