### PR TITLE
Changed git clone command in README.md

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -71,7 +71,7 @@ Running your own
 
 There are binaries on the [releases][release] page, or compile from source with:
 
-	$ git clone git@github.com:zgoat/goatcounter.git
+	$ git clone https://github.com/zgoat/goatcounter.git
 	$ cd goatcounter
 	$ go build ./cmd/goatcounter
 


### PR DESCRIPTION
I've changed the git clone command in the README.md to use GitHub's https:// based URL's (was an SSH address before) since these are the only once that work without signing in / using a public key that has been specifically granted access to this project.