### PR TITLE
Allow sending emails without a relay

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -71,9 +71,9 @@ Running your own
 
 Compile from source with:
 
-	$ git clone https://github.com/zgoat/goatcounter.git
-	$ cd goatcounter
-	$ go build ./cmd/goatcounter
+    $ git clone https://github.com/zgoat/goatcounter.git
+    $ cd goatcounter
+    $ go build ./cmd/goatcounter
 
 You'll now have a `goatcounter` binary in the current directory.
 
@@ -92,26 +92,26 @@ will need a C compiler (for SQLite) or PostgreSQL.
 
 You can start the server with:
 
-	goatcounter serve -dev
+    goatcounter serve -dev
 
 The default is to use a SQLite database at `./db/goatcounter.sqlite3` (will be
 created if it doesn't exist). See the `-db` flag to customize this.
 
 You can create new sites with the `create` command:
 
-	goatcounter create -email me@example.com -domain stats.example.com
+    goatcounter create -email me@example.com -domain stats.example.com
 
 If you use a custom DB, you must also pass the `-db` flag here.
 
 The `-dev` flag makes some small things a bit more convenient for development,
 such as logins. For a production environment run something like:
 
-    goatcounter serve \
-       -smtp         'smtp://localhost:25' \
-       -emailerrors  'me@example.com'
+    goatcounter serve
 
-`-smtp` is required to send login emails. You can use something like Mailtrap if
-you just want it for yourself, but you can also use your Gmail or whatnot.
+Using an SMTP relay via `-smtp` isn't required, but will usually guarantee
+better deliverability, so is recommended (delivering emails without them ending
+up in the spambox is hard). You should be able to use your
+gmail/FastMail/ProtonMail/etc. account for this.
 
 ### Updating
 
@@ -137,14 +137,12 @@ it:
 
        $ createdb goatcounter
        $ psql goatcounter -c '\i db/schema.pgsql'
-	   $ goatcounter migrate all
+       $ goatcounter migrate all
 
 2. Run with custom `-db` flag:
 
        $ goatcounter serve \
-           -db           'postgresql://user=goatcounter dbname=goatcounter sslmode=disable' \
-           -smtp         'smtp://localhost:25' \
-           -emailerrors  'me@example.com'
+           -db 'postgresql://user=goatcounter dbname=goatcounter sslmode=disable'
 
    See the [pq docs][pq] for more details on the connection string.
 

--- a/go.mod
+++ b/go.mod
@@ -18,7 +18,7 @@ require (
 	zgo.at/tz v0.0.0-20200207054238-b33e5ce779e4
 	zgo.at/utils v1.4.1
 	zgo.at/zdb v0.0.0-20200210152331-3173dfc581b0
-	zgo.at/zhttp v0.0.0-20200213205119-2cbf8136987c
+	zgo.at/zhttp v0.0.0-20200221070953-51a5a26d28be
 	zgo.at/zlog v1.0.9
 	zgo.at/zpack v1.0.1
 	zgo.at/zstripe v1.0.0

--- a/go.sum
+++ b/go.sum
@@ -67,6 +67,10 @@ zgo.at/zdb v0.0.0-20200210152331-3173dfc581b0 h1:1PcVjz/rSdJrBfNuMLWbLXI1oJCOZxD
 zgo.at/zdb v0.0.0-20200210152331-3173dfc581b0/go.mod h1:GT5Nyrxb9H6JszZtd7o0m5CPEd3C7DFqAeJt98nyNQI=
 zgo.at/zhttp v0.0.0-20200213205119-2cbf8136987c h1:OIOpiSFtksnOapiB/Q5z6LFAyNhwsMGJ4BHIawedOCY=
 zgo.at/zhttp v0.0.0-20200213205119-2cbf8136987c/go.mod h1:B4gILybCAq72LKsOlVA0sBGIgp+QGBT2VOX6YFqYG1I=
+zgo.at/zhttp v0.0.0-20200221065750-b59356c25911 h1:b/hrn4slEGyYSOohuJ9HjhTObMhLlGobBzZRmSIQTyY=
+zgo.at/zhttp v0.0.0-20200221065750-b59356c25911/go.mod h1:qpNbBXqMQVTnjYbUlaBT1+SHctAfsRUGmWL/Sdwsrwo=
+zgo.at/zhttp v0.0.0-20200221070953-51a5a26d28be h1:WFlHYzt0oBr0e8JTh/bqPgH0kdjKKKzqN8SazIgCn8c=
+zgo.at/zhttp v0.0.0-20200221070953-51a5a26d28be/go.mod h1:qpNbBXqMQVTnjYbUlaBT1+SHctAfsRUGmWL/Sdwsrwo=
 zgo.at/zlog v1.0.7 h1:Ppjb9VOBheqENQ28TWsOddG2qIVO4nGb0b/TPh/5sXc=
 zgo.at/zlog v1.0.7/go.mod h1:0RldP/sQzWwOCPsJogZcxnJneFt56T1zfDtIN/LcYec=
 zgo.at/zlog v1.0.9 h1:JRggYfHH9eF5daLW6cm9uitibTlKP85AdlK+q9x5vZ4=


### PR DESCRIPTION
Not necessarily the recommended method; but okay for simple use. Using a
local smtp relay is probably better for serious use.

Fixes #177