### PR TITLE
Allow configuring the From: email address

### DIFF
--- a/cfg/cfg.go
+++ b/cfg/cfg.go
@@ -13,4 +13,5 @@ var (
 	Saas         bool
 	Serve        bool
 	Port         string
+	LoginFrom    string
 )

--- a/handlers/website.go
+++ b/handlers/website.go
@@ -270,7 +270,7 @@ func (h website) doForgot(w http.ResponseWriter, r *http.Request) error {
 		}
 
 		err := zmail.Send("Your GoatCounter sites",
-			mail.Address{Name: "GoatCounter login", Address: "login@goatcounter.com"},
+			mail.Address{Name: "GoatCounter login", Address: cfg.LoginFrom},
 			[]mail.Address{{Name: name, Address: args.Email}},
 			body)
 		if err != nil {

--- a/user.go
+++ b/user.go
@@ -240,7 +240,7 @@ func (u *User) GetToken() string {
 func (u *User) SendLoginMail(ctx context.Context, site *Site) {
 	go func() {
 		err := zmail.Send("Your login URL",
-			mail.Address{Name: "GoatCounter login", Address: "login@goatcounter.com"},
+			mail.Address{Name: "GoatCounter login", Address: cfg.LoginFrom},
 			[]mail.Address{{Name: u.Name, Address: u.Email}},
 			fmt.Sprintf("Hi there,\n\nYour login URL for Goatcounter is:\n\n  %s/user/login/%s\n\nGo to it to log in. This key is valid for one hour and can be used only once.\n",
 				site.URL(), *u.LoginRequest))


### PR DESCRIPTION
- Add new from_addr to -errors

- Add new -auth parameter to configure the authentication used and
  options for it. This only supports "email" now, but will be expanded
  later.

Fixes #140