### PR TITLE
Correct regex for RFC1918 private networks.

### DIFF
--- a/public/count.js
+++ b/public/count.js
@@ -70,7 +70,7 @@
 			endpoint = script.dataset.goatcounter;
 
 		// Don't track private networks.
-		if (!goatcounter.allow_local && location.hostname.match(/(localhost$|^127\.|^10\.|^172\.16\.|^192\.168\.)/))
+		if (!goatcounter.allow_local && location.hostname.match(/(localhost$|^127\.|^10\.|^172\.(1[6-9]|2[0-9]|3[0-1])\.|^192\.168\.)/))
 			return;
 
 		var data = get_data(count_vars || {});


### PR DESCRIPTION
Per [RFC1918](https://tools.ietf.org/html/rfc1918), the 172.16 private network is not 172.16.0.0/16 (172.16.0.0 - 172.16.255.255), but 172.16.0.0/**12** (172.16.0.0 - 172.31.255.255).

Needs a longer regex to match correctly.
