### PR TITLE
Use a size_stats table

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,6 @@ env:
 cache:
   directories:
     - '$HOME/.cache/go-build'
-    - '$GOPATH'
 notifications:
   email: false
 

--- a/cron/size_stat.go
+++ b/cron/size_stat.go
@@ -1,0 +1,92 @@
+// Copyright © 2019 Martin Tournoij <martin@arp242.net>
+// This file is part of GoatCounter and published under the terms of the EUPL
+// v1.2, which can be found in the LICENSE file or at http://eupl12.zgo.at
+
+package cron
+
+import (
+	"context"
+	"database/sql"
+	"strconv"
+
+	"github.com/pkg/errors"
+	"zgo.at/goatcounter"
+	"zgo.at/zdb"
+	"zgo.at/zdb/bulk"
+)
+
+// Size stats are stored as a simple day/width with a count.
+//  site |    day     | width    | count
+// ------+------------+----------+-------
+//     1 | 2019-11-30 | 380      |     1
+//     1 | 2019-11-30 | 1920     |     2
+//     1 | 2019-11-30 | 1920     |     4
+func updateSizeStats(ctx context.Context, hits []goatcounter.Hit) error {
+	return zdb.TX(ctx, func(ctx context.Context, tx zdb.DB) error {
+		// Group by day + width.
+		type gt struct {
+			count int
+			day   string
+			width int
+		}
+		grouped := map[string]gt{}
+		for _, h := range hits {
+
+			var width int
+			if len(h.Size) > 0 {
+				// TODO: apply scaling?
+				width = int(h.Size[0])
+			}
+
+			day := h.CreatedAt.Format("2006-01-02")
+
+			k := day + strconv.FormatInt(int64(width), 10)
+			v := grouped[k]
+			if v.count == 0 {
+				v.day = day
+				v.width = width
+				var err error
+				v.count, err = existingSizeStats(ctx, tx, h.Site, day, v.width)
+				if err != nil {
+					return err
+				}
+			}
+
+			v.count += 1
+			grouped[k] = v
+		}
+
+		siteID := goatcounter.MustGetSite(ctx).ID
+		ins := bulk.NewInsert(ctx, tx,
+			"size_stats", []string{"site", "day", "width", "count"})
+		for _, v := range grouped {
+			ins.Values(siteID, v.day, v.width, v.count)
+		}
+		return ins.Finish()
+	})
+}
+
+func existingSizeStats(
+	txctx context.Context, tx zdb.DB, siteID int64,
+	day string, width int,
+) (int, error) {
+
+	var c int
+	err := tx.GetContext(txctx, &c,
+		`select count from size_stats where site=$1 and day=$2 and width=$3`,
+		siteID, day, width)
+	if err != nil && err != sql.ErrNoRows {
+		return 0, errors.Wrap(err, "existing")
+	}
+
+	if err != sql.ErrNoRows {
+		_, err = tx.ExecContext(txctx,
+			`delete from size_stats where site=$1 and day=$2 and width=$3`,
+			siteID, day, width)
+		if err != nil {
+			return 0, errors.Wrap(err, "delete")
+		}
+	}
+
+	return c, nil
+}

--- a/cron/size_stat_test.go
+++ b/cron/size_stat_test.go
@@ -1,0 +1,71 @@
+// Copyright © 2019 Martin Tournoij <martin@arp242.net>
+// This file is part of GoatCounter and published under the terms of the EUPL
+// v1.2, which can be found in the LICENSE file or at http://eupl12.zgo.at
+
+package cron_test
+
+import (
+	"fmt"
+	"testing"
+	"time"
+
+	"zgo.at/goatcounter"
+	. "zgo.at/goatcounter/cron"
+	"zgo.at/goatcounter/gctest"
+)
+
+func TestSizeStats(t *testing.T) {
+	ctx, clean := gctest.DB(t)
+	defer clean()
+
+	site := goatcounter.MustGetSite(ctx)
+	now := time.Date(2019, 8, 31, 14, 42, 0, 0, time.UTC)
+
+	err := UpdateStats(ctx, site.ID, []goatcounter.Hit{
+		{Site: site.ID, CreatedAt: now, Size: []float64{1920, 1080, 1}},
+		{Site: site.ID, CreatedAt: now, Size: []float64{1920, 1080, 1}},
+		{Site: site.ID, CreatedAt: now, Size: []float64{1024, 768, 1}},
+		{Site: site.ID, CreatedAt: now, Size: []float64{}},
+		{Site: site.ID, CreatedAt: now, Size: nil},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var stats goatcounter.Stats
+	total, err := stats.ListSizes(ctx, now, now)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	want := `5 -> [{Phones 0} {Large phones, small tablets 1} {Tablets and small laptops 0} {Computer monitors 2} {Computer monitors larger than HD 0} {(unknown) 2}]`
+	out := fmt.Sprintf("%d -> %v", total, stats)
+	if want != out {
+		t.Errorf("\nwant: %s\nout:  %s", want, out)
+	}
+
+	// Update existing.
+	err = UpdateStats(ctx, site.ID, []goatcounter.Hit{
+		{Site: site.ID, CreatedAt: now, Size: []float64{1920, 1080, 1}},
+		{Site: site.ID, CreatedAt: now, Size: []float64{1024, 768, 1}},
+		{Site: site.ID, CreatedAt: now, Size: []float64{1920, 1080, 1}},
+		{Site: site.ID, CreatedAt: now, Size: []float64{1024, 768, 1}},
+		{Site: site.ID, CreatedAt: now, Size: []float64{380, 600, 1}},
+		{Site: site.ID, CreatedAt: now, Size: nil},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	stats = goatcounter.Stats{}
+	total, err = stats.ListSizes(ctx, now, now)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	want = `11 -> [{Phones 1} {Large phones, small tablets 3} {Tablets and small laptops 0} {Computer monitors 4} {Computer monitors larger than HD 0} {(unknown) 3}]`
+	out = fmt.Sprintf("%d -> %v", total, stats)
+	if want != out {
+		t.Errorf("\nwant: %s\nout:  %s", want, out)
+	}
+}

--- a/db/migrate/pgsql/2020-03-16-1-size_stats.sql
+++ b/db/migrate/pgsql/2020-03-16-1-size_stats.sql
@@ -1,0 +1,15 @@
+begin;
+	create table size_stats (
+		site           integer        not null                 check(site > 0),
+
+		day            date           not null,
+		width          int           not null,
+		count          int            not null,
+
+		foreign key (site) references sites(id) on delete restrict on update restrict
+	);
+	create index "size_stats#site#day"       on size_stats(site, day);
+	create index "size_stats#site#day#width" on size_stats(site, day, width);
+
+	insert into version values ('2020-03-16-1-size_stats');
+commit;

--- a/db/migrate/sqlite/2020-03-16-1-size_stats.sql
+++ b/db/migrate/sqlite/2020-03-16-1-size_stats.sql
@@ -1,0 +1,15 @@
+begin;
+	create table size_stats (
+		site           integer        not null                 check(site > 0),
+
+		day            date           not null                 check(day = strftime('%Y-%m-%d', day)),
+		width          int           not null,
+		count          int            not null,
+
+		foreign key (site) references sites(id) on delete restrict on update restrict
+	);
+	create index "size_stats#site#day"       on size_stats(site, day);
+	create index "size_stats#site#day#width" on size_stats(site, day, width);
+
+	insert into version values ('2020-03-16-1-size_stats');
+commit;

--- a/handlers/backend.go
+++ b/handlers/backend.go
@@ -368,6 +368,9 @@ func (h backend) index(w http.ResponseWriter, r *http.Request) error {
 
 func (h backend) topRefs(w http.ResponseWriter, r *http.Request) error {
 	start, end, err := getPeriod(w, r, goatcounter.MustGetSite(r.Context()))
+	if err != nil {
+		return err
+	}
 
 	var refs goatcounter.Stats
 	o, _ := strconv.ParseInt(r.URL.Query().Get("offset"), 10, 64)
@@ -387,6 +390,9 @@ func (h backend) topRefs(w http.ResponseWriter, r *http.Request) error {
 
 func (h backend) pagesByRef(w http.ResponseWriter, r *http.Request) error {
 	start, end, err := getPeriod(w, r, goatcounter.MustGetSite(r.Context()))
+	if err != nil {
+		return err
+	}
 
 	var hits goatcounter.Stats
 	total, err := hits.ByRef(r.Context(), start, end, r.URL.Query().Get("name"))
@@ -495,6 +501,9 @@ func (h backend) adminSite(w http.ResponseWriter, r *http.Request) error {
 
 func (h backend) refs(w http.ResponseWriter, r *http.Request) error {
 	start, end, err := getPeriod(w, r, goatcounter.MustGetSite(r.Context()))
+	if err != nil {
+		return err
+	}
 
 	offset := 0
 	if o := r.URL.Query().Get("offset"); o != "" {
@@ -527,6 +536,9 @@ func (h backend) refs(w http.ResponseWriter, r *http.Request) error {
 
 func (h backend) browsers(w http.ResponseWriter, r *http.Request) error {
 	start, end, err := getPeriod(w, r, goatcounter.MustGetSite(r.Context()))
+	if err != nil {
+		return err
+	}
 
 	var browsers goatcounter.Stats
 	total, err := browsers.ListBrowser(r.Context(), r.URL.Query().Get("name"), start, end)
@@ -544,6 +556,9 @@ func (h backend) browsers(w http.ResponseWriter, r *http.Request) error {
 
 func (h backend) sizes(w http.ResponseWriter, r *http.Request) error {
 	start, end, err := getPeriod(w, r, goatcounter.MustGetSite(r.Context()))
+	if err != nil {
+		return err
+	}
 
 	var sizeStat goatcounter.Stats
 	total, err := sizeStat.ListSize(r.Context(), r.URL.Query().Get("name"), start, end)
@@ -561,6 +576,9 @@ func (h backend) sizes(w http.ResponseWriter, r *http.Request) error {
 
 func (h backend) locations(w http.ResponseWriter, r *http.Request) error {
 	start, end, err := getPeriod(w, r, goatcounter.MustGetSite(r.Context()))
+	if err != nil {
+		return err
+	}
 
 	var locStat goatcounter.Stats
 	total, err := locStat.ListLocations(r.Context(), start, end)
@@ -578,6 +596,9 @@ func (h backend) pages(w http.ResponseWriter, r *http.Request) error {
 	site := goatcounter.MustGetSite(r.Context())
 
 	start, end, err := getPeriod(w, r, site)
+	if err != nil {
+		return err
+	}
 	daily, forcedDaily := getDaily(r, start, end)
 
 	var pages goatcounter.HitStats

--- a/pack/pack.go
+++ b/pack/pack.go
@@ -676,6 +676,22 @@ commit;
 	insert into version values ('2020-03-13-1-code-moved');
 commit;
 `),
+	"db/migrate/pgsql/2020-03-16-1-size_stats.sql": []byte(`begin;
+	create table size_stats (
+		site           integer        not null                 check(site > 0),
+
+		day            date           not null,
+		width          int           not null,
+		count          int            not null,
+
+		foreign key (site) references sites(id) on delete restrict on update restrict
+	);
+	create index "size_stats#site#day"       on size_stats(site, day);
+	create index "size_stats#site#day#width" on size_stats(site, day, width);
+
+	insert into version values ('2020-03-16-1-size_stats');
+commit;
+`),
 }
 
 var MigrationsSQLite = map[string][]byte{
@@ -1362,6 +1378,22 @@ commit;
 	);
 
 	insert into version values ('2020-03-03-1-flag');
+commit;
+`),
+	"db/migrate/sqlite/2020-03-16-1-size_stats.sql": []byte(`begin;
+	create table size_stats (
+		site           integer        not null                 check(site > 0),
+
+		day            date           not null                 check(day = strftime('%Y-%m-%d', day)),
+		width          int           not null,
+		count          int            not null,
+
+		foreign key (site) references sites(id) on delete restrict on update restrict
+	);
+	create index "size_stats#site#day"       on size_stats(site, day);
+	create index "size_stats#site#day#width" on size_stats(site, day, width);
+
+	insert into version values ('2020-03-16-1-size_stats');
 commit;
 `),
 }

--- a/site.go
+++ b/site.go
@@ -425,7 +425,7 @@ func (s Site) DeleteOlderThan(ctx context.Context, days int) error {
 			return errors.Wrap(err, "Site.DeleteOlderThan: delete sites")
 		}
 
-		for _, t := range []string{"hit_stats", "browser_stats", "location_stats"} {
+		for _, t := range []string{"hit_stats", "browser_stats", "location_stats", "ref_stats", "size_stats"} {
 			_, err := tx.ExecContext(ctx,
 				`delete from `+t+` where site=$1 and day < `+ival,
 				s.ID)


### PR DESCRIPTION
Don't know why I didn't use a table for this one; it's a massive performance
win.

Before when selecting a month:

	backend  1219ms  pages.List
	backend     3ms  browsers.List
	backend   554ms  sizeStat.ListSizes
	backend     6ms  locStat.List
	backend     2ms  topRefs.List
	backend    13ms  zhttp.Template

After:

	backend  1020ms  pages.List
	backend     5ms  browsers.List
	backend     2ms  sizeStat.ListSizes
	backend     5ms  locStat.List
	backend     5ms  topRefs.List
	backend    33ms  zhttp.Template