### PR TITLE
Display future charts as greyed out

### DIFF
--- a/pack/pack.go
+++ b/pack/pack.go
@@ -12731,7 +12731,7 @@ http://nicolasgallagher.com/micro-clearfix-hack/
 					date  = split[0];
 					start = split[1];
 					end   = split[3];
-					views = ', ' + split[4] + ' ' + split[5];
+					views = ', ' + split[4] + (split[5] ? (' ' + split[5]) : '');
 
 					if (!SETTINGS.twenty_four_hours) {
 						start = un24(start);
@@ -13280,7 +13280,9 @@ form .err  { color: red; display: block; }
 	*/
 
 }
-.chart-bar > div:hover       { background-color: #aaa; }
+.chart-bar > div:hover  { background-color: #aaa; }
+.chart-bar > .f         { background-color: #eee; }
+
 
 #popup {
 	position: absolute;

--- a/public/script_backend.js
+++ b/public/script_backend.js
@@ -606,7 +606,7 @@
 					date  = split[0];
 					start = split[1];
 					end   = split[3];
-					views = ', ' + split[4] + ' ' + split[5];
+					views = ', ' + split[4] + (split[5] ? (' ' + split[5]) : '');
 
 					if (!SETTINGS.twenty_four_hours) {
 						start = un24(start);

--- a/public/style_backend.css
+++ b/public/style_backend.css
@@ -209,7 +209,9 @@ form .err  { color: red; display: block; }
 	*/
 
 }
-.chart-bar > div:hover       { background-color: #aaa; }
+.chart-bar > div:hover  { background-color: #aaa; }
+.chart-bar > .f         { background-color: #eee; }
+
 
 #popup {
 	position: absolute;


### PR DESCRIPTION
You get future dates if you will in "current week" or month. I think
this makes sense, but it's currently a bit unclear where the future
begins.