### PR TITLE
Collect all the migrations in the schema files

### DIFF
--- a/.github/CONTRIBUTING.markdown
+++ b/.github/CONTRIBUTING.markdown
@@ -84,6 +84,12 @@ straightforward
   first. The cron package will persist that to DB every 10 seconds, which also
   regenerates various cached stats.
 
+- Hits ("pageviews") are stored in the `hits` table with minimal processing; for
+  the most part, this table isn't queried directly for reasons of performance.
+  When inserting new rows in the table the various `*_stats` tables are updated
+  as well, which contain a more efficient aggregation of the data (`hit_stats`,
+  browser_stats`, etc.)
+
 - Templates live in /tpl, and are standard Go templates. The Go template library
   is a bit idiosyncratic, but once you "get" it they're quite pleasant to work
   with (I can't find a good/gentle "getting started with Go templates"
@@ -92,3 +98,5 @@ straightforward
 
 - The frontend is in /public. It's all simple basic CSS with simple jQuery-based
   JavaScript.
+
+

--- a/README.markdown
+++ b/README.markdown
@@ -133,11 +133,12 @@ be faster in most cases, and the chief reason for adding support in the first
 place is to support load balancing web requests over multiple servers. To use
 it:
 
-1. Create the database, unlike SQLite it's not done automatically:
+1. Create the database, unlike SQLite it's not done automatically (you may need
+   to modify the `-db` flag):
 
        $ createdb goatcounter
        $ psql goatcounter -c '\i db/schema.pgsql'
-       $ goatcounter migrate all
+       $ goatcounter -db 'postgresql://dbname=goatcounter' migrate all
 
 2. Run with custom `-db` flag:
 

--- a/db/migrate/pgsql/2020-03-16-2-rm-old.sql
+++ b/db/migrate/pgsql/2020-03-16-2-rm-old.sql
@@ -1,0 +1,11 @@
+begin;
+	alter table hit_stats drop column total;
+	alter table sites     drop column last_stat;
+
+	alter table sites
+		drop constraint if exists sites_domain_check;
+	alter table sites
+		add constraint sites_link_domain_check check(link_domain = '' or (length(link_domain) >= 4 and length(link_domain) <= 255));
+
+	insert into version values ('2020-03-16-2-rm-old');
+commit;

--- a/db/migrate/sqlite/2020-03-16-2-rm-old.sql
+++ b/db/migrate/sqlite/2020-03-16-2-rm-old.sql
@@ -1,0 +1,47 @@
+begin;
+	--alter table hit_stats drop column total;
+	create table hit_stats2 (
+		site           integer        not null                 check(site > 0),
+
+		day            date           not null                 check(day = strftime('%Y-%m-%d', day)),
+		path           varchar        not null,
+		title          varchar        not null default '',
+		stats          varchar        not null,
+
+		foreign key (site) references sites(id) on delete restrict on update restrict
+	);
+	insert into hit_stats2
+		(site, day, path, title, stats)
+		select site, day, path, title, stats from hit_stats;
+	drop table hit_stats;
+	alter table hit_stats2 rename to hit_stats;
+
+	--alter table sites     drop column last_stat;
+	--alter table sites
+	--	drop constraint if exists sites_domain_check;
+	--alter table sites
+	--	add constraint sites_link_domain_check check(length(link_domain) >= 4 and length(link_domain) <= 255);
+	create table sites2 (
+		id             integer        primary key autoincrement,
+		parent         integer        null                     check(parent is null or parent>0),
+
+		name           varchar        not null                 check(length(name) >= 4 and length(name) <= 255),
+		code           varchar        not null                 check(length(code) >= 2   and length(code) <= 50),
+		link_domain    varchar        not null default ''      check(link_domain = '' or (length(link_domain) >= 4 and length(link_domain) <= 255)),
+		cname          varchar        null                     check(cname is null or (length(cname) >= 4 and length(cname) <= 255)),
+		plan           varchar        not null                 check(plan in ('personal', 'personalplus', 'business', 'businessplus', 'child', 'custom')),
+		stripe         varchar        null,
+		settings       varchar        not null,
+		received_data  int            not null default 0,
+
+		state          varchar        not null default 'a'     check(state in ('a', 'd')),
+		created_at     timestamp      not null                 check(created_at = strftime('%Y-%m-%d %H:%M:%S', created_at)),
+		updated_at     timestamp                               check(updated_at = strftime('%Y-%m-%d %H:%M:%S', updated_at))
+	);
+	insert into sites2
+		select id, parent, name, code, link_domain, cname, plan, stripe, settings, received_data, state, created_at, updated_at from sites;
+	drop table sites;
+	alter table sites2 rename to sites;
+
+	insert into version values ('2020-03-16-2-rm-old');
+commit;

--- a/db/schema.pgsql
+++ b/db/schema.pgsql
@@ -1,5 +1,38 @@
 drop table if exists version;
 create table version (name varchar);
+insert into version values
+	('2019-10-16-1-geoip'),
+	('2019-11-08-1-refs'),
+	('2019-11-08-2-location_stats'),
+	('2019-12-10-1-plans'),
+	('2019-12-10-2-count_ref'),
+	('2019-12-15-1-personal-free'),
+	('2019-12-15-2-old'),
+	('2019-12-17-1-business'),
+	('2019-12-19-1-updates'),
+	('2019-12-20-1-dailystat'),
+	('2019-12-31-1-blank-days'),
+	('2020-01-02-1-bot'),
+	('2020-01-07-1-title-domain'),
+	('2020-01-13-1-update'),
+	('2020-01-13-2-hit_stats_title'),
+	('2020-01-18-1-sitename'),
+	('2020-01-23-1-nformat'),
+	('2020-01-23-2-retention'),
+	('2020-01-24-1-rm-mobile'),
+	('2020-01-24-2-domain'),
+	('2020-01-26-1-sitecode'),
+	('2020-01-27-1-ignore'),
+	('2020-01-27-2-rm-count-ref'),
+	('2020-02-02-1-tz'),
+	('2020-02-06-1-hitsid'),
+	('2020-02-19-1-personalplus'),
+	('2020-02-19-2-outage'),
+	('2020-02-24-1-ref_stats'),
+	('2020-03-03-1-flag'),
+	('2020-03-13-1-code-moved'),
+	('2020-03-16-1-size_stats'),
+	('2020-03-16-2-rm-old');
 
 drop table if exists sites cascade;
 create table sites (
@@ -8,11 +41,11 @@ create table sites (
 
 	name           varchar        not null                 check(length(name) >= 4 and length(name) <= 255),
 	code           varchar        not null                 check(length(code) >= 2 and length(code) <= 50),
+	link_domain    varchar        not null default ''      check(link_domain = '' or (length(link_domain) >= 4 and length(link_domain) <= 255)),
 	cname          varchar        null                     check(cname is null or (length(cname) >= 4 and length(cname) <= 255)),
-	plan           varchar        not null                 check(plan in ('p', 'b', 'e', 'c')),
+	plan           varchar        not null                 check(plan in ('personal', 'personalplus', 'business', 'businessplus', 'child', 'custom')),
 	stripe         varchar        null,
 	settings       varchar        not null,
-	last_stat      timestamp      null,
 	received_data  int            not null default 0,
 
 	state          varchar        not null default 'a'     check(state in ('a', 'd')),
@@ -20,7 +53,6 @@ create table sites (
 	updated_at     timestamp
 );
 create unique index "sites#code"  on sites(lower(code));
-create unique index "sites#name"  on sites(lower(name));
 create unique index "sites#cname" on sites(lower(cname));
 
 drop table if exists users cascade;
@@ -35,6 +67,7 @@ create table users (
 	login_request  varchar        null,
 	login_token    varchar        null,
 	csrf_token     varchar        null,
+	seen_updates_at timestamp     not null default current_timestamp,
 
 	created_at     timestamp      not null,
 	updated_at     timestamp,
@@ -48,20 +81,25 @@ create unique index "users#site#email"    on users(site, lower(email));
 
 drop table if exists hits cascade;
 create table hits (
+	id             serial primary key,
 	site           integer        not null                 check(site > 0),
 
 	path           varchar        not null,
+	title          varchar        not null default '',
+	event          int            default 0,
+	bot            int            default 0,
 	ref            varchar        not null,
 	ref_original   varchar,
 	ref_params     varchar,
 	ref_scheme     varchar        null                     check(ref_scheme in ('h', 'g', 'o')),
 	browser        varchar        not null,
 	size           varchar        not null default '',
+	location       varchar        not null default '',
 
 	created_at     timestamp      not null
 );
-create index "hits#site#created_at"      on hits(site, created_at);
-create index "hits#site#path#created_at" on hits(site, lower(path), created_at);
+create index "hits#site#bot#created_at"      on hits(site, bot, created_at);
+create index "hits#site#bot#path#created_at" on hits(site, bot, lower(path), created_at);
 
 drop table if exists hit_stats cascade;
 create table hit_stats (
@@ -69,10 +107,8 @@ create table hit_stats (
 
 	day            date           not null,
 	path           varchar        not null,
+	title          varchar        not null default '',
 	stats          varchar        not null,
-
-	created_at     timestamp      null,
-	updated_at     timestamp,
 
 	foreign key (site) references sites(id) on delete restrict on update restrict
 );
@@ -86,9 +122,373 @@ create table browser_stats (
 	browser        varchar        not null,
 	version        varchar        not null,
 	count          int            not null,
-	mobile         int default 0  not null,
 
 	foreign key (site) references sites(id) on delete restrict on update restrict
 );
 create index "browser_stats#site#day"         on browser_stats(site, day);
 create index "browser_stats#site#day#browser" on browser_stats(site, day, browser);
+
+drop table if exists location_stats;
+create table location_stats (
+	site           integer        not null                 check(site > 0),
+
+	day            date           not null,
+	location       varchar        not null,
+	count          int            not null,
+
+	foreign key (site) references sites(id) on delete restrict on update restrict
+);
+create index "location_stats#site#day"          on location_stats(site, day);
+create index "location_stats#site#day#location" on location_stats(site, day, location);
+
+drop table if exists ref_stats;
+create table ref_stats (
+	site           integer        not null                 check(site > 0),
+
+	day            date           not null,
+	ref            varchar        not null,
+	count          int            not null,
+
+	foreign key (site) references sites(id) on delete restrict on update restrict
+);
+create index "ref_stats#site#day" on ref_stats(site, day);
+
+drop table if exists size_stats;
+create table size_stats (
+	site           integer        not null                 check(site > 0),
+
+	day            date           not null,
+	width          int           not null,
+	count          int            not null,
+
+	foreign key (site) references sites(id) on delete restrict on update restrict
+);
+create index "size_stats#site#day"       on size_stats(site, day);
+create index "size_stats#site#day#width" on size_stats(site, day, width);
+
+drop table if exists iso_3166_1;
+create table iso_3166_1 (
+	name   varchar,
+	alpha2 varchar
+);
+create index "iso_3166_1#alpha2" on iso_3166_1(alpha2);
+insert into iso_3166_1 (name, alpha2) values
+	('(unknown)', ''),
+
+	('Ascension Island', 'AC'),
+	('Andorra', 'AD'),
+	('United Arab Emirates', 'AE'),
+	('Afghanistan', 'AF'),
+	('Antigua and Barbuda', 'AG'),
+	('Anguilla', 'AI'),
+	('Albania', 'AL'),
+	('Armenia', 'AM'),
+	('Netherlands Antilles', 'AN'),
+	('Angola', 'AO'),
+	('Antarctica', 'AQ'),
+	('Argentina', 'AR'),
+	('American Samoa', 'AS'),
+	('Austria', 'AT'),
+	('Australia', 'AU'),
+	('Aruba', 'AW'),
+	('Åland Islands', 'AX'),
+	('Azerbaijan', 'AZ'),
+	('Bosnia and Herzegovina', 'BA'),
+	('Barbados', 'BB'),
+	('Bangladesh', 'BD'),
+	('Belgium', 'BE'),
+	('Burkina Faso', 'BF'),
+	('Bulgaria', 'BG'),
+	('Bahrain', 'BH'),
+	('Burundi', 'BI'),
+	('Benin', 'BJ'),
+	('Saint Barthélemy', 'BL'),
+	('Bermuda', 'BM'),
+	('Brunei Darussalam', 'BN'),
+	('Bolivia', 'BO'),
+	('Bonaire, Sint Eustatius and Saba', 'BQ'),
+	('Brazil', 'BR'),
+	('Bahamas', 'BS'),
+	('Bhutan', 'BT'),
+	('Burma', 'BU'),
+	('Bouvet Island', 'BV'),
+	('Botswana', 'BW'),
+	('Belarus', 'BY'),
+	('Belize', 'BZ'),
+	('Canada', 'CA'),
+	('Cocos (Keeling) Islands', 'CC'),
+	('Democratic Republic of thje Congo', 'CD'),
+	('Central African Republic', 'CF'),
+	('Congo', 'CG'),
+	('Switzerland', 'CH'),
+	('Côte d''Ivoire', 'CI'),
+	('Cook Islands', 'CK'),
+	('Chile', 'CL'),
+	('Cameroon', 'CM'),
+	('China', 'CN'),
+	('Colombia', 'CO'),
+	('Clipperton Island', 'CP'),
+	('Costa Rica', 'CR'),
+	('Serbia and Montenegro', 'CS'),
+	('Cuba', 'CU'),
+	('Cabo Verde', 'CV'),
+	('Curaçao', 'CW'),
+	('Christmas Island', 'CX'),
+	('Cyprus', 'CY'),
+	('Czechia', 'CZ'),
+	('Germany', 'DE'),
+	('Diego Garcia', 'DG'),
+	('Djibouti', 'DJ'),
+	('Denmark', 'DK'),
+	('Dominica', 'DM'),
+	('Dominican Republic', 'DO'),
+	('Benin', 'DY'),
+	('Algeria', 'DZ'),
+	('Ceuta, Melilla', 'EA'),
+	('Ecuador', 'EC'),
+	('Estonia', 'EE'),
+	('Egypt', 'EG'),
+	('Western Sahara', 'EH'),
+	('Eritrea', 'ER'),
+	('Spain', 'ES'),
+	('Ethiopia', 'ET'),
+	('European Union', 'EU'),
+	('Estonia', 'EW'),
+	('Eurozone', 'EZ'),
+	('Finland', 'FI'),
+	('Fiji', 'FJ'),
+	('Falkland Islands (Malvinas)', 'FK'),
+	('Liechtenstein', 'FL'),
+	('Micronesia', 'FM'),
+	('Faroe Islands', 'FO'),
+	('France', 'FR'),
+	('France, Metropolitan', 'FX'),
+	('Gabon', 'GA'),
+	('United Kingdom', 'GB'),
+	('Grenada', 'GD'),
+	('Georgia', 'GE'),
+	('French Guiana', 'GF'),
+	('Guernsey', 'GG'),
+	('Ghana', 'GH'),
+	('Gibraltar', 'GI'),
+	('Greenland', 'GL'),
+	('Gambia', 'GM'),
+	('Guinea', 'GN'),
+	('Guadeloupe', 'GP'),
+	('Equatorial Guinea', 'GQ'),
+	('Greece', 'GR'),
+	('South Georgia and the South Sandwich Islands', 'GS'),
+	('Guatemala', 'GT'),
+	('Guam', 'GU'),
+	('Guinea-Bissau', 'GW'),
+	('Guyana', 'GY'),
+	('Hong Kong', 'HK'),
+	('Heard Island and McDonald Islands', 'HM'),
+	('Honduras', 'HN'),
+	('Croatia', 'HR'),
+	('Haiti', 'HT'),
+	('Hungary', 'HU'),
+	('Canary Islands', 'IC'),
+	('Indonesia', 'ID'),
+	('Ireland', 'IE'),
+	('Israel', 'IL'),
+	('Isle of Man', 'IM'),
+	('India', 'IN'),
+	('British Indian Ocean Territory', 'IO'),
+	('Iraq', 'IQ'),
+	('Iran', 'IR'),
+	('Iceland', 'IS'),
+	('Italy', 'IT'),
+	('Jamaica', 'JA'),
+	('Jersey', 'JE'),
+	('Jamaica', 'JM'),
+	('Jordan', 'JO'),
+	('Japan', 'JP'),
+	('Kenya', 'KE'),
+	('Kyrgyzstan', 'KG'),
+	('Cambodia', 'KH'),
+	('Kiribati', 'KI'),
+	('Comoros', 'KM'),
+	('Saint Kitts and Nevis', 'KN'),
+	('North Korea', 'KP'),
+	('South Korea', 'KR'),
+	('Kuwait', 'KW'),
+	('Cayman Islands', 'KY'),
+	('Kazakhstan', 'KZ'),
+	('Lao People''s Democratic Republic', 'LA'),
+	('Lebanon', 'LB'),
+	('Saint Lucia', 'LC'),
+	('Libya Fezzan', 'LF'),
+	('Liechtenstein', 'LI'),
+	('Sri Lanka', 'LK'),
+	('Liberia', 'LR'),
+	('Lesotho', 'LS'),
+	('Lithuania', 'LT'),
+	('Luxembourg', 'LU'),
+	('Latvia', 'LV'),
+	('Libya', 'LY'),
+	('Morocco', 'MA'),
+	('Monaco', 'MC'),
+	('Moldova, Republic of', 'MD'),
+	('Montenegro', 'ME'),
+	('Saint Martin (French part)', 'MF'),
+	('Madagascar', 'MG'),
+	('Marshall Islands', 'MH'),
+	('North Macedonia', 'MK'),
+	('Mali', 'ML'),
+	('Myanmar', 'MM'),
+	('Mongolia', 'MN'),
+	('Macao', 'MO'),
+	('Northern Mariana Islands', 'MP'),
+	('Martinique', 'MQ'),
+	('Mauritania', 'MR'),
+	('Montserrat', 'MS'),
+	('Malta', 'MT'),
+	('Mauritius', 'MU'),
+	('Maldives', 'MV'),
+	('Malawi', 'MW'),
+	('Mexico', 'MX'),
+	('Malaysia', 'MY'),
+	('Mozambique', 'MZ'),
+	('Namibia', 'NA'),
+	('New Caledonia', 'NC'),
+	('Niger', 'NE'),
+	('Norfolk Island', 'NF'),
+	('Nigeria', 'NG'),
+	('Nicaragua', 'NI'),
+	('Netherlands', 'NL'),
+	('Norway', 'NO'),
+	('Nepal', 'NP'),
+	('Nauru', 'NR'),
+	('Neutral Zone', 'NT'),
+	('Niue', 'NU'),
+	('New Zealand', 'NZ'),
+	('Oman', 'OM'),
+	('Escape code', 'OO'),
+	('Panama', 'PA'),
+	('Peru', 'PE'),
+	('French Polynesia', 'PF'),
+	('Papua New Guinea', 'PG'),
+	('Philippines', 'PH'),
+	('Philippines', 'PI'),
+	('Pakistan', 'PK'),
+	('Poland', 'PL'),
+	('Saint Pierre and Miquelon', 'PM'),
+	('Pitcairn', 'PN'),
+	('Puerto Rico', 'PR'),
+	('Palestine, State of', 'PS'),
+	('Portugal', 'PT'),
+	('Palau', 'PW'),
+	('Paraguay', 'PY'),
+	('Qatar', 'QA'),
+	('Argentina', 'RA'),
+	('Bolivia; Botswana', 'RB'),
+	('China', 'RC'),
+	('Réunion', 'RE'),
+	('Haiti', 'RH'),
+	('Indonesia', 'RI'),
+	('Lebanon', 'RL'),
+	('Madagascar', 'RM'),
+	('Niger', 'RN'),
+	('Romania', 'RO'),
+	('Philippines', 'RP'),
+	('Serbia', 'RS'),
+	('Russian Federation', 'RU'),
+	('Rwanda', 'RW'),
+	('Saudi Arabia', 'SA'),
+	('Solomon Islands', 'SB'),
+	('Seychelles', 'SC'),
+	('Sudan', 'SD'),
+	('Sweden', 'SE'),
+	('Finland', 'SF'),
+	('Singapore', 'SG'),
+	('Saint Helena, Ascension and Tristan da Cunha', 'SH'),
+	('Slovenia', 'SI'),
+	('Svalbard and Jan Mayen', 'SJ'),
+	('Slovakia', 'SK'),
+	('Sierra Leone', 'SL'),
+	('San Marino', 'SM'),
+	('Senegal', 'SN'),
+	('Somalia', 'SO'),
+	('Suriname', 'SR'),
+	('South Sudan', 'SS'),
+	('Sao Tome and Principe', 'ST'),
+	('USSR', 'SU'),
+	('El Salvador', 'SV'),
+	('Sint Maarten (Dutch part)', 'SX'),
+	('Syrian Arab Republic', 'SY'),
+	('Eswatini', 'SZ'),
+	('Tristan da Cunha', 'TA'),
+	('Turks and Caicos Islands', 'TC'),
+	('Chad', 'TD'),
+	('French Southern Territories', 'TF'),
+	('Togo', 'TG'),
+	('Thailand', 'TH'),
+	('Tajikistan', 'TJ'),
+	('Tokelau', 'TK'),
+	('Timor-Leste', 'TL'),
+	('Turkmenistan', 'TM'),
+	('Tunisia', 'TN'),
+	('Tonga', 'TO'),
+	('East Timor', 'TP'),
+	('Turkey', 'TR'),
+	('Trinidad and Tobago', 'TT'),
+	('Tuvalu', 'TV'),
+	('Taiwan', 'TW'),
+	('Tanzania', 'TZ'),
+	('Ukraine', 'UA'),
+	('Uganda', 'UG'),
+	('United Kingdom', 'UK'),
+	('United States Minor Outlying Islands', 'UM'),
+	('United Nations', 'UN'),
+	('United States', 'US'),
+	('Uruguay', 'UY'),
+	('Uzbekistan', 'UZ'),
+	('Holy See', 'VA'),
+	('Saint Vincent and the Grenadines', 'VC'),
+	('Venezuela', 'VE'),
+	('Virgin Islands (British)', 'VG'),
+	('Virgin Islands (U.S.)', 'VI'),
+	('Viet Nam', 'VN'),
+	('Vanuatu', 'VU'),
+	('Wallis and Futuna', 'WF'),
+	('Grenada', 'WG'),
+	('Saint Lucia', 'WL'),
+	('Samoa', 'WS'),
+	('Saint Vincent', 'WV'),
+	('Yemen', 'YE'),
+	('Mayotte', 'YT'),
+	('Yugoslavia', 'YU'),
+	('Venezuela', 'YV'),
+	('South Africa', 'ZA'),
+	('Zambia', 'ZM'),
+	('Zaire', 'ZR'),
+	('Zimbabwe', 'ZW');
+
+drop table if exists updates;
+create table updates (
+	id             serial         primary key,
+	subject        varchar        not null,
+	body           varchar        not null,
+
+	created_at     timestamp      not null,
+	show_at        timestamp      not null
+);
+
+drop table if exists usage;
+create table usage (
+	site           integer        not null                 check(site > 0),
+	domain         varchar        not null,
+	count          integer        not null,
+	vetted         integer        default 0,
+
+	foreign key (site) references sites(id) on delete restrict on update restrict
+);
+
+drop table if exists flags;
+create table flags (
+	name  varchar not null,
+	value int     not null
+);
+
+-- vim:ft=sql

--- a/hit.go
+++ b/hit.go
@@ -51,8 +51,6 @@ type Hit struct {
 
 	RefURL      *url.URL `db:"-"` // Parsed Ref
 	UsageDomain string   `db:"-"` // Track referrer for usage.
-
-	D string `json:"dep"` // TODO: no longer sent, can remove in future.
 }
 
 var groups = map[string]string{

--- a/pack/pack.go
+++ b/pack/pack.go
@@ -692,6 +692,18 @@ commit;
 	insert into version values ('2020-03-16-1-size_stats');
 commit;
 `),
+	"db/migrate/pgsql/2020-03-16-2-rm-old.sql": []byte(`begin;
+	alter table hit_stats drop column total;
+	alter table sites     drop column last_stat;
+
+	alter table sites
+		drop constraint if exists sites_domain_check;
+	alter table sites
+		add constraint sites_link_domain_check check(link_domain = '' or (length(link_domain) >= 4 and length(link_domain) <= 255));
+
+	insert into version values ('2020-03-16-2-rm-old');
+commit;
+`),
 }
 
 var MigrationsSQLite = map[string][]byte{
@@ -1394,6 +1406,54 @@ commit;
 	create index "size_stats#site#day#width" on size_stats(site, day, width);
 
 	insert into version values ('2020-03-16-1-size_stats');
+commit;
+`),
+	"db/migrate/sqlite/2020-03-16-2-rm-old.sql": []byte(`begin;
+	--alter table hit_stats drop column total;
+	create table hit_stats2 (
+		site           integer        not null                 check(site > 0),
+
+		day            date           not null                 check(day = strftime('%Y-%m-%d', day)),
+		path           varchar        not null,
+		title          varchar        not null default '',
+		stats          varchar        not null,
+
+		foreign key (site) references sites(id) on delete restrict on update restrict
+	);
+	insert into hit_stats2
+		(site, day, path, title, stats)
+		select site, day, path, title, stats from hit_stats;
+	drop table hit_stats;
+	alter table hit_stats2 rename to hit_stats;
+
+	--alter table sites     drop column last_stat;
+	--alter table sites
+	--	drop constraint if exists sites_domain_check;
+	--alter table sites
+	--	add constraint sites_link_domain_check check(length(link_domain) >= 4 and length(link_domain) <= 255);
+	create table sites2 (
+		id             integer        primary key autoincrement,
+		parent         integer        null                     check(parent is null or parent>0),
+
+		name           varchar        not null                 check(length(name) >= 4 and length(name) <= 255),
+		code           varchar        not null                 check(length(code) >= 2   and length(code) <= 50),
+		link_domain    varchar        not null default ''      check(link_domain = '' or (length(link_domain) >= 4 and length(link_domain) <= 255)),
+		cname          varchar        null                     check(cname is null or (length(cname) >= 4 and length(cname) <= 255)),
+		plan           varchar        not null                 check(plan in ('personal', 'personalplus', 'business', 'businessplus', 'child', 'custom')),
+		stripe         varchar        null,
+		settings       varchar        not null,
+		received_data  int            not null default 0,
+
+		state          varchar        not null default 'a'     check(state in ('a', 'd')),
+		created_at     timestamp      not null                 check(created_at = strftime('%Y-%m-%d %H:%M:%S', created_at)),
+		updated_at     timestamp                               check(updated_at = strftime('%Y-%m-%d %H:%M:%S', updated_at))
+	);
+	insert into sites2
+		select id, parent, name, code, link_domain, cname, plan, stripe, settings, received_data, state, created_at, updated_at from sites;
+	drop table sites;
+	alter table sites2 rename to sites;
+
+	insert into version values ('2020-03-16-2-rm-old');
 commit;
 `),
 }
@@ -13481,6 +13541,39 @@ h3 + h4 { margin-top: .3em; }
 
 var SchemaPgSQL = []byte(`drop table if exists version;
 create table version (name varchar);
+insert into version values
+	('2019-10-16-1-geoip'),
+	('2019-11-08-1-refs'),
+	('2019-11-08-2-location_stats'),
+	('2019-12-10-1-plans'),
+	('2019-12-10-2-count_ref'),
+	('2019-12-15-1-personal-free'),
+	('2019-12-15-2-old'),
+	('2019-12-17-1-business'),
+	('2019-12-19-1-updates'),
+	('2019-12-20-1-dailystat'),
+	('2019-12-31-1-blank-days'),
+	('2020-01-02-1-bot'),
+	('2020-01-07-1-title-domain'),
+	('2020-01-13-1-update'),
+	('2020-01-13-2-hit_stats_title'),
+	('2020-01-18-1-sitename'),
+	('2020-01-23-1-nformat'),
+	('2020-01-23-2-retention'),
+	('2020-01-24-1-rm-mobile'),
+	('2020-01-24-2-domain'),
+	('2020-01-26-1-sitecode'),
+	('2020-01-27-1-ignore'),
+	('2020-01-27-2-rm-count-ref'),
+	('2020-02-02-1-tz'),
+	('2020-02-06-1-hitsid'),
+	('2020-02-19-1-personalplus'),
+	('2020-02-19-2-outage'),
+	('2020-02-24-1-ref_stats'),
+	('2020-03-03-1-flag'),
+	('2020-03-13-1-code-moved'),
+	('2020-03-16-1-size_stats'),
+	('2020-03-16-2-rm-old');
 
 drop table if exists sites cascade;
 create table sites (
@@ -13489,11 +13582,11 @@ create table sites (
 
 	name           varchar        not null                 check(length(name) >= 4 and length(name) <= 255),
 	code           varchar        not null                 check(length(code) >= 2 and length(code) <= 50),
+	link_domain    varchar        not null default ''      check(link_domain = '' or (length(link_domain) >= 4 and length(link_domain) <= 255)),
 	cname          varchar        null                     check(cname is null or (length(cname) >= 4 and length(cname) <= 255)),
-	plan           varchar        not null                 check(plan in ('p', 'b', 'e', 'c')),
+	plan           varchar        not null                 check(plan in ('personal', 'personalplus', 'business', 'businessplus', 'child', 'custom')),
 	stripe         varchar        null,
 	settings       varchar        not null,
-	last_stat      timestamp      null,
 	received_data  int            not null default 0,
 
 	state          varchar        not null default 'a'     check(state in ('a', 'd')),
@@ -13501,7 +13594,6 @@ create table sites (
 	updated_at     timestamp
 );
 create unique index "sites#code"  on sites(lower(code));
-create unique index "sites#name"  on sites(lower(name));
 create unique index "sites#cname" on sites(lower(cname));
 
 drop table if exists users cascade;
@@ -13516,6 +13608,7 @@ create table users (
 	login_request  varchar        null,
 	login_token    varchar        null,
 	csrf_token     varchar        null,
+	seen_updates_at timestamp     not null default current_timestamp,
 
 	created_at     timestamp      not null,
 	updated_at     timestamp,
@@ -13529,20 +13622,25 @@ create unique index "users#site#email"    on users(site, lower(email));
 
 drop table if exists hits cascade;
 create table hits (
+	id             serial primary key,
 	site           integer        not null                 check(site > 0),
 
 	path           varchar        not null,
+	title          varchar        not null default '',
+	event          int            default 0,
+	bot            int            default 0,
 	ref            varchar        not null,
 	ref_original   varchar,
 	ref_params     varchar,
 	ref_scheme     varchar        null                     check(ref_scheme in ('h', 'g', 'o')),
 	browser        varchar        not null,
 	size           varchar        not null default '',
+	location       varchar        not null default '',
 
 	created_at     timestamp      not null
 );
-create index "hits#site#created_at"      on hits(site, created_at);
-create index "hits#site#path#created_at" on hits(site, lower(path), created_at);
+create index "hits#site#bot#created_at"      on hits(site, bot, created_at);
+create index "hits#site#bot#path#created_at" on hits(site, bot, lower(path), created_at);
 
 drop table if exists hit_stats cascade;
 create table hit_stats (
@@ -13550,10 +13648,8 @@ create table hit_stats (
 
 	day            date           not null,
 	path           varchar        not null,
+	title          varchar        not null default '',
 	stats          varchar        not null,
-
-	created_at     timestamp      null,
-	updated_at     timestamp,
 
 	foreign key (site) references sites(id) on delete restrict on update restrict
 );
@@ -13567,12 +13663,376 @@ create table browser_stats (
 	browser        varchar        not null,
 	version        varchar        not null,
 	count          int            not null,
-	mobile         int default 0  not null,
 
 	foreign key (site) references sites(id) on delete restrict on update restrict
 );
 create index "browser_stats#site#day"         on browser_stats(site, day);
 create index "browser_stats#site#day#browser" on browser_stats(site, day, browser);
+
+drop table if exists location_stats;
+create table location_stats (
+	site           integer        not null                 check(site > 0),
+
+	day            date           not null,
+	location       varchar        not null,
+	count          int            not null,
+
+	foreign key (site) references sites(id) on delete restrict on update restrict
+);
+create index "location_stats#site#day"          on location_stats(site, day);
+create index "location_stats#site#day#location" on location_stats(site, day, location);
+
+drop table if exists ref_stats;
+create table ref_stats (
+	site           integer        not null                 check(site > 0),
+
+	day            date           not null,
+	ref            varchar        not null,
+	count          int            not null,
+
+	foreign key (site) references sites(id) on delete restrict on update restrict
+);
+create index "ref_stats#site#day" on ref_stats(site, day);
+
+drop table if exists size_stats;
+create table size_stats (
+	site           integer        not null                 check(site > 0),
+
+	day            date           not null,
+	width          int           not null,
+	count          int            not null,
+
+	foreign key (site) references sites(id) on delete restrict on update restrict
+);
+create index "size_stats#site#day"       on size_stats(site, day);
+create index "size_stats#site#day#width" on size_stats(site, day, width);
+
+drop table if exists iso_3166_1;
+create table iso_3166_1 (
+	name   varchar,
+	alpha2 varchar
+);
+create index "iso_3166_1#alpha2" on iso_3166_1(alpha2);
+insert into iso_3166_1 (name, alpha2) values
+	('(unknown)', ''),
+
+	('Ascension Island', 'AC'),
+	('Andorra', 'AD'),
+	('United Arab Emirates', 'AE'),
+	('Afghanistan', 'AF'),
+	('Antigua and Barbuda', 'AG'),
+	('Anguilla', 'AI'),
+	('Albania', 'AL'),
+	('Armenia', 'AM'),
+	('Netherlands Antilles', 'AN'),
+	('Angola', 'AO'),
+	('Antarctica', 'AQ'),
+	('Argentina', 'AR'),
+	('American Samoa', 'AS'),
+	('Austria', 'AT'),
+	('Australia', 'AU'),
+	('Aruba', 'AW'),
+	('Åland Islands', 'AX'),
+	('Azerbaijan', 'AZ'),
+	('Bosnia and Herzegovina', 'BA'),
+	('Barbados', 'BB'),
+	('Bangladesh', 'BD'),
+	('Belgium', 'BE'),
+	('Burkina Faso', 'BF'),
+	('Bulgaria', 'BG'),
+	('Bahrain', 'BH'),
+	('Burundi', 'BI'),
+	('Benin', 'BJ'),
+	('Saint Barthélemy', 'BL'),
+	('Bermuda', 'BM'),
+	('Brunei Darussalam', 'BN'),
+	('Bolivia', 'BO'),
+	('Bonaire, Sint Eustatius and Saba', 'BQ'),
+	('Brazil', 'BR'),
+	('Bahamas', 'BS'),
+	('Bhutan', 'BT'),
+	('Burma', 'BU'),
+	('Bouvet Island', 'BV'),
+	('Botswana', 'BW'),
+	('Belarus', 'BY'),
+	('Belize', 'BZ'),
+	('Canada', 'CA'),
+	('Cocos (Keeling) Islands', 'CC'),
+	('Democratic Republic of thje Congo', 'CD'),
+	('Central African Republic', 'CF'),
+	('Congo', 'CG'),
+	('Switzerland', 'CH'),
+	('Côte d''Ivoire', 'CI'),
+	('Cook Islands', 'CK'),
+	('Chile', 'CL'),
+	('Cameroon', 'CM'),
+	('China', 'CN'),
+	('Colombia', 'CO'),
+	('Clipperton Island', 'CP'),
+	('Costa Rica', 'CR'),
+	('Serbia and Montenegro', 'CS'),
+	('Cuba', 'CU'),
+	('Cabo Verde', 'CV'),
+	('Curaçao', 'CW'),
+	('Christmas Island', 'CX'),
+	('Cyprus', 'CY'),
+	('Czechia', 'CZ'),
+	('Germany', 'DE'),
+	('Diego Garcia', 'DG'),
+	('Djibouti', 'DJ'),
+	('Denmark', 'DK'),
+	('Dominica', 'DM'),
+	('Dominican Republic', 'DO'),
+	('Benin', 'DY'),
+	('Algeria', 'DZ'),
+	('Ceuta, Melilla', 'EA'),
+	('Ecuador', 'EC'),
+	('Estonia', 'EE'),
+	('Egypt', 'EG'),
+	('Western Sahara', 'EH'),
+	('Eritrea', 'ER'),
+	('Spain', 'ES'),
+	('Ethiopia', 'ET'),
+	('European Union', 'EU'),
+	('Estonia', 'EW'),
+	('Eurozone', 'EZ'),
+	('Finland', 'FI'),
+	('Fiji', 'FJ'),
+	('Falkland Islands (Malvinas)', 'FK'),
+	('Liechtenstein', 'FL'),
+	('Micronesia', 'FM'),
+	('Faroe Islands', 'FO'),
+	('France', 'FR'),
+	('France, Metropolitan', 'FX'),
+	('Gabon', 'GA'),
+	('United Kingdom', 'GB'),
+	('Grenada', 'GD'),
+	('Georgia', 'GE'),
+	('French Guiana', 'GF'),
+	('Guernsey', 'GG'),
+	('Ghana', 'GH'),
+	('Gibraltar', 'GI'),
+	('Greenland', 'GL'),
+	('Gambia', 'GM'),
+	('Guinea', 'GN'),
+	('Guadeloupe', 'GP'),
+	('Equatorial Guinea', 'GQ'),
+	('Greece', 'GR'),
+	('South Georgia and the South Sandwich Islands', 'GS'),
+	('Guatemala', 'GT'),
+	('Guam', 'GU'),
+	('Guinea-Bissau', 'GW'),
+	('Guyana', 'GY'),
+	('Hong Kong', 'HK'),
+	('Heard Island and McDonald Islands', 'HM'),
+	('Honduras', 'HN'),
+	('Croatia', 'HR'),
+	('Haiti', 'HT'),
+	('Hungary', 'HU'),
+	('Canary Islands', 'IC'),
+	('Indonesia', 'ID'),
+	('Ireland', 'IE'),
+	('Israel', 'IL'),
+	('Isle of Man', 'IM'),
+	('India', 'IN'),
+	('British Indian Ocean Territory', 'IO'),
+	('Iraq', 'IQ'),
+	('Iran', 'IR'),
+	('Iceland', 'IS'),
+	('Italy', 'IT'),
+	('Jamaica', 'JA'),
+	('Jersey', 'JE'),
+	('Jamaica', 'JM'),
+	('Jordan', 'JO'),
+	('Japan', 'JP'),
+	('Kenya', 'KE'),
+	('Kyrgyzstan', 'KG'),
+	('Cambodia', 'KH'),
+	('Kiribati', 'KI'),
+	('Comoros', 'KM'),
+	('Saint Kitts and Nevis', 'KN'),
+	('North Korea', 'KP'),
+	('South Korea', 'KR'),
+	('Kuwait', 'KW'),
+	('Cayman Islands', 'KY'),
+	('Kazakhstan', 'KZ'),
+	('Lao People''s Democratic Republic', 'LA'),
+	('Lebanon', 'LB'),
+	('Saint Lucia', 'LC'),
+	('Libya Fezzan', 'LF'),
+	('Liechtenstein', 'LI'),
+	('Sri Lanka', 'LK'),
+	('Liberia', 'LR'),
+	('Lesotho', 'LS'),
+	('Lithuania', 'LT'),
+	('Luxembourg', 'LU'),
+	('Latvia', 'LV'),
+	('Libya', 'LY'),
+	('Morocco', 'MA'),
+	('Monaco', 'MC'),
+	('Moldova, Republic of', 'MD'),
+	('Montenegro', 'ME'),
+	('Saint Martin (French part)', 'MF'),
+	('Madagascar', 'MG'),
+	('Marshall Islands', 'MH'),
+	('North Macedonia', 'MK'),
+	('Mali', 'ML'),
+	('Myanmar', 'MM'),
+	('Mongolia', 'MN'),
+	('Macao', 'MO'),
+	('Northern Mariana Islands', 'MP'),
+	('Martinique', 'MQ'),
+	('Mauritania', 'MR'),
+	('Montserrat', 'MS'),
+	('Malta', 'MT'),
+	('Mauritius', 'MU'),
+	('Maldives', 'MV'),
+	('Malawi', 'MW'),
+	('Mexico', 'MX'),
+	('Malaysia', 'MY'),
+	('Mozambique', 'MZ'),
+	('Namibia', 'NA'),
+	('New Caledonia', 'NC'),
+	('Niger', 'NE'),
+	('Norfolk Island', 'NF'),
+	('Nigeria', 'NG'),
+	('Nicaragua', 'NI'),
+	('Netherlands', 'NL'),
+	('Norway', 'NO'),
+	('Nepal', 'NP'),
+	('Nauru', 'NR'),
+	('Neutral Zone', 'NT'),
+	('Niue', 'NU'),
+	('New Zealand', 'NZ'),
+	('Oman', 'OM'),
+	('Escape code', 'OO'),
+	('Panama', 'PA'),
+	('Peru', 'PE'),
+	('French Polynesia', 'PF'),
+	('Papua New Guinea', 'PG'),
+	('Philippines', 'PH'),
+	('Philippines', 'PI'),
+	('Pakistan', 'PK'),
+	('Poland', 'PL'),
+	('Saint Pierre and Miquelon', 'PM'),
+	('Pitcairn', 'PN'),
+	('Puerto Rico', 'PR'),
+	('Palestine, State of', 'PS'),
+	('Portugal', 'PT'),
+	('Palau', 'PW'),
+	('Paraguay', 'PY'),
+	('Qatar', 'QA'),
+	('Argentina', 'RA'),
+	('Bolivia; Botswana', 'RB'),
+	('China', 'RC'),
+	('Réunion', 'RE'),
+	('Haiti', 'RH'),
+	('Indonesia', 'RI'),
+	('Lebanon', 'RL'),
+	('Madagascar', 'RM'),
+	('Niger', 'RN'),
+	('Romania', 'RO'),
+	('Philippines', 'RP'),
+	('Serbia', 'RS'),
+	('Russian Federation', 'RU'),
+	('Rwanda', 'RW'),
+	('Saudi Arabia', 'SA'),
+	('Solomon Islands', 'SB'),
+	('Seychelles', 'SC'),
+	('Sudan', 'SD'),
+	('Sweden', 'SE'),
+	('Finland', 'SF'),
+	('Singapore', 'SG'),
+	('Saint Helena, Ascension and Tristan da Cunha', 'SH'),
+	('Slovenia', 'SI'),
+	('Svalbard and Jan Mayen', 'SJ'),
+	('Slovakia', 'SK'),
+	('Sierra Leone', 'SL'),
+	('San Marino', 'SM'),
+	('Senegal', 'SN'),
+	('Somalia', 'SO'),
+	('Suriname', 'SR'),
+	('South Sudan', 'SS'),
+	('Sao Tome and Principe', 'ST'),
+	('USSR', 'SU'),
+	('El Salvador', 'SV'),
+	('Sint Maarten (Dutch part)', 'SX'),
+	('Syrian Arab Republic', 'SY'),
+	('Eswatini', 'SZ'),
+	('Tristan da Cunha', 'TA'),
+	('Turks and Caicos Islands', 'TC'),
+	('Chad', 'TD'),
+	('French Southern Territories', 'TF'),
+	('Togo', 'TG'),
+	('Thailand', 'TH'),
+	('Tajikistan', 'TJ'),
+	('Tokelau', 'TK'),
+	('Timor-Leste', 'TL'),
+	('Turkmenistan', 'TM'),
+	('Tunisia', 'TN'),
+	('Tonga', 'TO'),
+	('East Timor', 'TP'),
+	('Turkey', 'TR'),
+	('Trinidad and Tobago', 'TT'),
+	('Tuvalu', 'TV'),
+	('Taiwan', 'TW'),
+	('Tanzania', 'TZ'),
+	('Ukraine', 'UA'),
+	('Uganda', 'UG'),
+	('United Kingdom', 'UK'),
+	('United States Minor Outlying Islands', 'UM'),
+	('United Nations', 'UN'),
+	('United States', 'US'),
+	('Uruguay', 'UY'),
+	('Uzbekistan', 'UZ'),
+	('Holy See', 'VA'),
+	('Saint Vincent and the Grenadines', 'VC'),
+	('Venezuela', 'VE'),
+	('Virgin Islands (British)', 'VG'),
+	('Virgin Islands (U.S.)', 'VI'),
+	('Viet Nam', 'VN'),
+	('Vanuatu', 'VU'),
+	('Wallis and Futuna', 'WF'),
+	('Grenada', 'WG'),
+	('Saint Lucia', 'WL'),
+	('Samoa', 'WS'),
+	('Saint Vincent', 'WV'),
+	('Yemen', 'YE'),
+	('Mayotte', 'YT'),
+	('Yugoslavia', 'YU'),
+	('Venezuela', 'YV'),
+	('South Africa', 'ZA'),
+	('Zambia', 'ZM'),
+	('Zaire', 'ZR'),
+	('Zimbabwe', 'ZW');
+
+drop table if exists updates;
+create table updates (
+	id             serial         primary key,
+	subject        varchar        not null,
+	body           varchar        not null,
+
+	created_at     timestamp      not null,
+	show_at        timestamp      not null
+);
+
+drop table if exists usage;
+create table usage (
+	site           integer        not null                 check(site > 0),
+	domain         varchar        not null,
+	count          integer        not null,
+	vetted         integer        default 0,
+
+	foreign key (site) references sites(id) on delete restrict on update restrict
+);
+
+drop table if exists flags;
+create table flags (
+	name  varchar not null,
+	value int     not null
+);
+
+-- vim:ft=sql
 `)
 var SchemaSQLite = []byte(`drop table if exists version;
 create table version (name varchar);
@@ -13595,7 +14055,13 @@ insert into version values
 	('2020-01-23-1-nformat'),
 	('2020-01-24-1-rm-mobile'),
 	('2020-01-24-2-domain'),
-	('2020-01-27-2-rm-count-ref');
+	('2020-01-27-2-rm-count-ref'),
+	('2020-02-06-1-hitsid'),
+	('2020-02-19-1-personalplus'),
+	('2020-02-24-1-ref_stats'),
+	('2020-03-03-1-flag'),
+	('2020-03-16-1-size_stats'),
+	('2020-03-16-2-rm-old');
 
 drop table if exists sites;
 create table sites (
@@ -13604,13 +14070,12 @@ create table sites (
 
 	name           varchar        not null                 check(length(name) >= 4 and length(name) <= 255),
 	code           varchar        not null                 check(length(code) >= 2   and length(code) <= 50),
+	link_domain    varchar        not null default ''      check(link_domain = '' or (length(link_domain) >= 4 and length(link_domain) <= 255)),
 	cname          varchar        null                     check(cname is null or (length(cname) >= 4 and length(cname) <= 255)),
-	plan           varchar        not null                 check(plan in ('personal', 'business', 'businessplus', 'child', 'custom')),
+	plan           varchar        not null                 check(plan in ('personal', 'personalplus', 'business', 'businessplus', 'child', 'custom')),
 	stripe         varchar        null,
 	settings       varchar        not null,
-	last_stat      timestamp      null                     check(last_stat = strftime('%Y-%m-%d %H:%M:%S', last_stat)),
 	received_data  int            not null default 0,
-	link_domain    varchar        not null default '',
 
 	state          varchar        not null default 'a'     check(state in ('a', 'd')),
 	created_at     timestamp      not null                 check(created_at = strftime('%Y-%m-%d %H:%M:%S', created_at)),
@@ -13644,9 +14109,13 @@ create unique index "users#site#email"    on users(site, lower(email));
 
 drop table if exists hits;
 create table hits (
+	id             integer        primary key autoincrement,
 	site           integer        not null                 check(site > 0),
 
 	path           varchar        not null,
+	title          varchar        not null default '',
+	event          int            default 0,
+	bot            int            default 0,
 	ref            varchar        not null,
 	ref_original   varchar,
 	ref_params     varchar,
@@ -13654,9 +14123,6 @@ create table hits (
 	browser        varchar        not null,
 	size           varchar        not null default '',
 	location       varchar        not null default '',
-	bot            int            default 0,
-	title          varchar        not null default '',
-	event          int            default 0,
 
 	created_at     timestamp      not null                 check(created_at = strftime('%Y-%m-%d %H:%M:%S', created_at))
 );
@@ -13671,7 +14137,6 @@ create table hit_stats (
 	path           varchar        not null,
 	title          varchar        not null default '',
 	stats          varchar        not null,
-	total          integer        not null default 0,
 
 	foreign key (site) references sites(id) on delete restrict on update restrict
 );
@@ -13691,6 +14156,7 @@ create table browser_stats (
 create index "browser_stats#site#day"         on browser_stats(site, day);
 create index "browser_stats#site#day#browser" on browser_stats(site, day, browser);
 
+drop table if exists location_stats;
 create table location_stats (
 	site           integer        not null                 check(site > 0),
 
@@ -13703,6 +14169,32 @@ create table location_stats (
 create index "location_stats#site#day"          on location_stats(site, day);
 create index "location_stats#site#day#location" on location_stats(site, day, location);
 
+drop table if exists ref_stats;
+create table ref_stats (
+	site           integer        not null                 check(site > 0),
+
+	day            date           not null                 check(day = strftime('%Y-%m-%d', day)),
+	ref            varchar        not null,
+	count          int            not null,
+
+	foreign key (site) references sites(id) on delete restrict on update restrict
+);
+create index "ref_stats#site#day" on ref_stats(site, day);
+
+drop table if exists size_stats;
+create table size_stats (
+	site           integer        not null                 check(site > 0),
+
+	day            date           not null                 check(day = strftime('%Y-%m-%d', day)),
+	width          int           not null,
+	count          int            not null,
+
+	foreign key (site) references sites(id) on delete restrict on update restrict
+);
+create index "size_stats#site#day"       on size_stats(site, day);
+create index "size_stats#site#day#width" on size_stats(site, day, width);
+
+drop table if exists iso_3166_1;
 create table iso_3166_1 (
 	name   varchar,
 	alpha2 varchar
@@ -14019,6 +14511,12 @@ create table usage (
 	vetted         integer        default 0,
 
 	foreign key (site) references sites(id) on delete restrict on update restrict
+);
+
+drop table if exists flags;
+create table flags (
+	name  varchar not null,
+	value int     not null
 );
 `)
 var Templates = map[string][]byte{

--- a/site.go
+++ b/site.go
@@ -55,7 +55,6 @@ type Site struct {
 	Plan         string       `db:"plan"`
 	Stripe       *string      `db:"stripe"`
 	Settings     SiteSettings `db:"settings"`
-	LastStat     *time.Time   `db:"last_stat"` // TODO: unused, remove
 	ReceivedData bool         `db:"received_data"`
 
 	State     string     `db:"state"`


### PR DESCRIPTION
So you don't have to run loads of migrations on startup (faster tests!)
and so I have a clear overview of what the DB should look like.