### PR TITLE
Better support for campaigns

### DIFF
--- a/CHANGELOG.markdown
+++ b/CHANGELOG.markdown
@@ -16,7 +16,7 @@ UNRELEASED v1.2.0
 
   **Action required** Use the interface to set a password (you will get a
   notification about this). Email authentication still works, but will be
-  removed in the next release.
+  removed in the next release, after which updating the password will be tricky.
 
 - Unique visitor tracking (#212)
 
@@ -29,12 +29,19 @@ UNRELEASED v1.2.0
   The bot detection is now improved; this will be applied to older pageviews in
   the database with a migration, but the cached statistics aren't updated
   automatically (as it can take a while for larger sites). Use the `reindex`
-  command to fully update older. This is entirely optional.
+  command to fully update older pageviews (this is entirely optional).
 
 - Track events (#215)
 
   There is now better support to track events; see the updated documentation on
   the Site Code page for details.
+
+- Better support for campaigns (#238)
+
+  There is now a "campaign parameters" setting; if the URL matches one of these
+  parameters it will be set as the referrer (overriding the `Referer` header).
+
+  The default is `utm_campaign, utm_source, ref`.
 
 - Better export (#221)
 

--- a/cron/tasks.go
+++ b/cron/tasks.go
@@ -16,7 +16,6 @@ import (
 	"zgo.at/goatcounter/cfg"
 	"zgo.at/goatcounter/errors"
 	"zgo.at/zdb"
-	"zgo.at/zhttp/ctxkey"
 	"zgo.at/zlog"
 )
 
@@ -117,7 +116,7 @@ func UpdateStats(ctx context.Context, siteID int64, hits []goatcounter.Hit) erro
 	if err != nil {
 		return err
 	}
-	ctx = context.WithValue(ctx, ctxkey.Site, &site)
+	ctx = goatcounter.WithSite(ctx, &site)
 
 	err = updateHitStats(ctx, hits)
 	if err != nil {
@@ -165,7 +164,7 @@ func ReindexStats(ctx context.Context, hits []goatcounter.Hit, table string) err
 			}
 			return errors.Errorf("cron.ReindexStats: %w", err)
 		}
-		ctx = context.WithValue(ctx, ctxkey.Site, &site)
+		ctx = goatcounter.WithSite(ctx, &site)
 
 		switch table {
 		case "all":

--- a/cron/tasks_test.go
+++ b/cron/tasks_test.go
@@ -5,7 +5,6 @@
 package cron_test
 
 import (
-	"context"
 	"fmt"
 	"testing"
 	"time"
@@ -13,7 +12,6 @@ import (
 	"zgo.at/goatcounter"
 	. "zgo.at/goatcounter/cron"
 	"zgo.at/goatcounter/gctest"
-	"zgo.at/zhttp/ctxkey"
 )
 
 func TestDataRetention(t *testing.T) {
@@ -26,7 +24,7 @@ func TestDataRetention(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	ctx = context.WithValue(ctx, ctxkey.Site, &site)
+	ctx = goatcounter.WithSite(ctx, &site)
 
 	now := time.Now().UTC()
 	past := now.Add(-40 * 24 * time.Hour)

--- a/db/migrate/pgsql/2020-04-22-1-campaigns.sql
+++ b/db/migrate/pgsql/2020-04-22-1-campaigns.sql
@@ -1,0 +1,6 @@
+begin;
+	alter table hits drop constraint hits_ref_scheme_check;
+	alter table hits add constraint hits_ref_scheme_check check(ref_scheme in ('h', 'g', 'o', 'c'));
+
+	insert into version values ('2020-04-22-1-campaigns');
+commit;

--- a/db/migrate/sqlite/2020-04-22-1-campaigns.sql
+++ b/db/migrate/sqlite/2020-04-22-1-campaigns.sql
@@ -1,0 +1,30 @@
+begin;
+	-- alter table hits drop constraint hits_ref_scheme_check;
+	-- alter table hits add constraint hits_ref_scheme_check check(ref_scheme in ('h', 'g', 'o', 'c'));
+	create table hits2 (
+		id             integer        primary key autoincrement,
+		site           integer        not null                 check(site > 0),
+		session        integer        default null,
+
+		path           varchar        not null,
+		title          varchar        not null default '',
+		event          int            default 0,
+		bot            int            default 0,
+		ref            varchar        not null,
+		ref_original   varchar,
+		ref_params     varchar,
+		ref_scheme     varchar        null                     check(ref_scheme in ('h', 'g', 'o', 'c')),
+		browser        varchar        not null,
+		size           varchar        not null default '',
+		location       varchar        not null default '',
+		started_session int           default 0,
+
+		created_at     timestamp      not null                 check(created_at = strftime('%Y-%m-%d %H:%M:%S', created_at))
+	);
+
+	insert into hits2 select * from hits;
+	drop table hits;
+	rename hits2 to hits;
+
+	insert into version values ('2020-04-22-1-campaigns');
+commit;

--- a/db/schema.pgsql
+++ b/db/schema.pgsql
@@ -68,7 +68,7 @@ create table hits (
 	ref            varchar        not null,
 	ref_original   varchar,
 	ref_params     varchar,
-	ref_scheme     varchar        null                     check(ref_scheme in ('h', 'g', 'o')),
+	ref_scheme     varchar        null                     check(ref_scheme in ('h', 'g', 'o', 'c')),
 	browser        varchar        not null,
 	size           varchar        not null default '',
 	location       varchar        not null default '',
@@ -528,7 +528,7 @@ insert into version values
 	('2020-03-29-1-page_cost'),
 	('2020-04-06-1-event'),
 	('2020-04-16-1-pwauth'),
-	('2020-04-20-1-hitsindex');
-
+	('2020-04-20-1-hitsindex'),
+	('2020-04-22-1-campaigns');
 
 -- vim:ft=sql

--- a/db/schema.sql
+++ b/db/schema.sql
@@ -56,7 +56,7 @@ create table hits (
 	ref            varchar        not null,
 	ref_original   varchar,
 	ref_params     varchar,
-	ref_scheme     varchar        null                     check(ref_scheme in ('h', 'g', 'o')),
+	ref_scheme     varchar        null                     check(ref_scheme in ('h', 'g', 'o', 'c')),
 	browser        varchar        not null,
 	size           varchar        not null default '',
 	location       varchar        not null default '',
@@ -505,4 +505,5 @@ insert into version values
 	('2020-03-27-1-isbot'),
 	('2020-03-24-1-sessions'),
 	('2020-04-06-1-event'),
-	('2020-04-16-1-pwauth');
+	('2020-04-16-1-pwauth'),
+	('2020-04-22-1-campaigns');

--- a/gctest/gctest.go
+++ b/gctest/gctest.go
@@ -21,7 +21,6 @@ import (
 	"zgo.at/goatcounter/cron"
 	"zgo.at/zdb"
 	"zgo.at/zhttp"
-	"zgo.at/zhttp/ctxkey"
 )
 
 var (
@@ -160,8 +159,8 @@ func DB(t tester) (context.Context, func()) {
 	}
 
 	ctx := zdb.With(context.Background(), db)
-	ctx = context.WithValue(ctx, ctxkey.Site, &goatcounter.Site{ID: 1})
-	ctx = context.WithValue(ctx, ctxkey.User, &goatcounter.User{ID: 1, Site: 1})
+	ctx = goatcounter.WithSite(ctx, &goatcounter.Site{ID: 1})
+	ctx = goatcounter.WithUser(ctx, &goatcounter.User{ID: 1, Site: 1})
 
 	return ctx, func() {
 		db.Close()
@@ -225,5 +224,5 @@ func Site(ctx context.Context, t *testing.T, site goatcounter.Site) (context.Con
 		t.Fatal(err)
 	}
 
-	return context.WithValue(ctx, ctxkey.Site, &site), site
+	return goatcounter.WithSite(ctx, &site), site
 }

--- a/handlers/backend_test.go
+++ b/handlers/backend_test.go
@@ -87,6 +87,18 @@ func TestBackendCount(t *testing.T) {
 			RefScheme: ztest.SP("h"),
 			Size:      sqlutil.FloatList{40, 50, 1},
 		}},
+
+		{"campaign", url.Values{"p": {"/foo.html"}, "q": {"ref=XXX"}}, 200, goatcounter.Hit{
+			Path:      "/foo.html",
+			Ref:       "XXX",
+			RefScheme: ztest.SP("c"),
+		}},
+
+		{"campaign_override", url.Values{"p": {"/foo.html?ref=AAA"}, "q": {"ref=XXX"}}, 200, goatcounter.Hit{
+			Path:      "/foo.html",
+			Ref:       "XXX",
+			RefScheme: ztest.SP("c"),
+		}},
 	}
 
 	for _, tt := range tests {

--- a/handlers/http_test.go
+++ b/handlers/http_test.go
@@ -26,7 +26,6 @@ import (
 	"zgo.at/utils/sliceutil"
 	"zgo.at/zdb"
 	"zgo.at/zhttp"
-	"zgo.at/zhttp/ctxkey"
 	"zgo.at/zhttp/zmail"
 	"zgo.at/zlog"
 	"zgo.at/ztest"
@@ -171,7 +170,7 @@ func login(t *testing.T, rr *httptest.ResponseRecorder, r *http.Request, siteID 
 	r.Form.Set("csrf", *u.CSRFToken)
 
 	r.Header.Set("Cookie", "key="+*u.LoginToken)
-	*r = *r.WithContext(context.WithValue(r.Context(), ctxkey.User, u))
+	*r = *r.WithContext(goatcounter.WithUser(r.Context(), &u))
 }
 
 func newTest(ctx context.Context, method, path string, body io.Reader) (*http.Request, *httptest.ResponseRecorder) {

--- a/handlers/mw.go
+++ b/handlers/mw.go
@@ -15,7 +15,6 @@ import (
 	"zgo.at/guru"
 	"zgo.at/zdb"
 	"zgo.at/zhttp"
-	"zgo.at/zhttp/ctxkey"
 	"zgo.at/zlog"
 )
 
@@ -98,7 +97,7 @@ func addctx(db zdb.DB, loadSite bool) func(http.Handler) http.Handler {
 					return
 				}
 
-				*r = *r.WithContext(context.WithValue(r.Context(), ctxkey.Site, &s))
+				*r = *r.WithContext(goatcounter.WithSite(r.Context(), &s))
 			}
 
 			next.ServeHTTP(w, r)

--- a/handlers/website.go
+++ b/handlers/website.go
@@ -5,7 +5,6 @@
 package handlers // import "zgo.at/goatcounter/handlers"
 
 import (
-	"context"
 	"fmt"
 	"html/template"
 	"net/http"
@@ -20,7 +19,6 @@ import (
 	"zgo.at/tz"
 	"zgo.at/zdb"
 	"zgo.at/zhttp"
-	"zgo.at/zhttp/ctxkey"
 	"zgo.at/zhttp/zmail"
 	"zgo.at/zlog"
 	"zgo.at/zvalidate"
@@ -216,7 +214,7 @@ func (h website) doSignup(w http.ResponseWriter, r *http.Request) error {
 		return err
 	}
 
-	ctx := context.WithValue(r.Context(), ctxkey.Site, &site)
+	ctx := goatcounter.WithSite(r.Context(), &site)
 	err = user.RequestLogin(ctx)
 	if err != nil {
 		return err

--- a/helper.go
+++ b/helper.go
@@ -28,6 +28,11 @@ var States = []string{StateActive, StateRequest, StateDeleted}
 // Now gets the current time in UTC; can be overwritten in tests.
 var Now = func() time.Time { return time.Now().UTC() }
 
+// WithSite adds the site to the context.
+func WithSite(ctx context.Context, s *Site) context.Context {
+	return context.WithValue(ctx, ctxkey.Site, s)
+}
+
 // GetSite gets the current site.
 func GetSite(ctx context.Context) *Site {
 	s, _ := ctx.Value(ctxkey.Site).(*Site)
@@ -41,6 +46,11 @@ func MustGetSite(ctx context.Context) *Site {
 		panic("MustGetSite: no site on context")
 	}
 	return s
+}
+
+// WithUser adds the site to the context.
+func WithUser(ctx context.Context, u *User) context.Context {
+	return context.WithValue(ctx, ctxkey.User, u)
 }
 
 // GetUser gets the currently logged in user.

--- a/hit.go
+++ b/hit.go
@@ -275,10 +275,8 @@ func (h Hit) String() string {
 
 // Defaults sets fields to default values, unless they're already set.
 func (h *Hit) Defaults(ctx context.Context) {
-	site := GetSite(ctx)
-	if site != nil && site.ID > 0 { // Not set from memstore.
-		h.Site = site.ID
-	}
+	site := MustGetSite(ctx)
+	h.Site = site.ID
 
 	if h.CreatedAt.IsZero() {
 		h.CreatedAt = Now()
@@ -296,12 +294,6 @@ func (h *Hit) Defaults(ctx context.Context) {
 			return
 		}
 		q := u.Query()
-
-		var site Site
-		err = site.ByID(ctx, h.Site)
-		if err != nil { // TODO: return?
-			zlog.Error(err)
-		}
 
 		for _, c := range site.Settings.Campaigns {
 			if _, ok := q[c]; ok {

--- a/hit.go
+++ b/hit.go
@@ -32,6 +32,7 @@ var (
 	RefSchemeHTTP      = ptr("h")
 	RefSchemeOther     = ptr("o")
 	RefSchemeGenerated = ptr("g")
+	RefSchemeCampaign  = ptr("c")
 )
 
 type Hit struct {
@@ -299,6 +300,7 @@ func (h *Hit) Defaults(ctx context.Context) {
 			if _, ok := q[c]; ok {
 				h.Ref = q.Get(c)
 				h.RefURL = nil
+				h.RefScheme = RefSchemeCampaign
 				break
 			}
 		}

--- a/hit_test.go
+++ b/hit_test.go
@@ -14,7 +14,6 @@ import (
 
 	"zgo.at/goatcounter"
 	"zgo.at/goatcounter/gctest"
-	"zgo.at/zhttp/ctxkey"
 	"zgo.at/ztest"
 )
 
@@ -223,7 +222,7 @@ func TestHitDefaultsRef(t *testing.T) {
 		{"android-app://com.example.android", "com.example.android", nil, nil, "o"},
 	}
 
-	ctx := context.WithValue(context.Background(), ctxkey.Site, &goatcounter.Site{ID: 1})
+	ctx := goatcounter.WithSite(context.Background(), &goatcounter.Site{ID: 1})
 
 	for i, tt := range tests {
 		t.Run(fmt.Sprintf("%d", i), func(t *testing.T) {
@@ -269,7 +268,7 @@ func TestHitDefaultsPath(t *testing.T) {
 		{"/page?fbclid=foo&a=b", "/page?a=b"},
 	}
 
-	ctx := context.WithValue(context.Background(), ctxkey.Site, &goatcounter.Site{ID: 1})
+	ctx := goatcounter.WithSite(context.Background(), &goatcounter.Site{ID: 1})
 
 	for i, tt := range tests {
 		t.Run(fmt.Sprintf("%d", i), func(t *testing.T) {

--- a/pack/pack.go
+++ b/pack/pack.go
@@ -792,6 +792,13 @@ commit;
 	insert into version values ('2020-04-20-1-hitsindex');
 commit;
 `),
+	"db/migrate/pgsql/2020-04-22-1-campaigns.sql": []byte(`begin;
+	alter table hits drop constraint hits_ref_scheme_check;
+	alter table hits add constraint hits_ref_scheme_check check(ref_scheme in ('h', 'g', 'o', 'c'));
+
+	insert into version values ('2020-04-22-1-campaigns');
+commit;
+`),
 	"db/migrate/pgsql/2020-04-25-1-donate.sql": []byte(`begin;
 	delete from updates where subject='One-time donation option';
 	insert into updates (subject, created_at, show_at, body) values (
@@ -1637,6 +1644,37 @@ commit;
 	alter table users add column reset_at timestamp null;
 
 	insert into version values ('2020-04-16-1-pwauth');
+commit;
+`),
+	"db/migrate/sqlite/2020-04-22-1-campaigns.sql": []byte(`begin;
+	-- alter table hits drop constraint hits_ref_scheme_check;
+	-- alter table hits add constraint hits_ref_scheme_check check(ref_scheme in ('h', 'g', 'o', 'c'));
+	create table hits2 (
+		id             integer        primary key autoincrement,
+		site           integer        not null                 check(site > 0),
+		session        integer        default null,
+
+		path           varchar        not null,
+		title          varchar        not null default '',
+		event          int            default 0,
+		bot            int            default 0,
+		ref            varchar        not null,
+		ref_original   varchar,
+		ref_params     varchar,
+		ref_scheme     varchar        null                     check(ref_scheme in ('h', 'g', 'o', 'c')),
+		browser        varchar        not null,
+		size           varchar        not null default '',
+		location       varchar        not null default '',
+		started_session int           default 0,
+
+		created_at     timestamp      not null                 check(created_at = strftime('%Y-%m-%d %H:%M:%S', created_at))
+	);
+
+	insert into hits2 select * from hits;
+	drop table hits;
+	rename hits2 to hits;
+
+	insert into version values ('2020-04-22-1-campaigns');
 commit;
 `),
 }
@@ -13796,7 +13834,7 @@ create table hits (
 	ref            varchar        not null,
 	ref_original   varchar,
 	ref_params     varchar,
-	ref_scheme     varchar        null                     check(ref_scheme in ('h', 'g', 'o')),
+	ref_scheme     varchar        null                     check(ref_scheme in ('h', 'g', 'o', 'c')),
 	browser        varchar        not null,
 	size           varchar        not null default '',
 	location       varchar        not null default '',
@@ -14256,8 +14294,8 @@ insert into version values
 	('2020-03-29-1-page_cost'),
 	('2020-04-06-1-event'),
 	('2020-04-16-1-pwauth'),
-	('2020-04-20-1-hitsindex');
-
+	('2020-04-20-1-hitsindex'),
+	('2020-04-22-1-campaigns');
 
 -- vim:ft=sql
 `)
@@ -14319,7 +14357,7 @@ create table hits (
 	ref            varchar        not null,
 	ref_original   varchar,
 	ref_params     varchar,
-	ref_scheme     varchar        null                     check(ref_scheme in ('h', 'g', 'o')),
+	ref_scheme     varchar        null                     check(ref_scheme in ('h', 'g', 'o', 'c')),
 	browser        varchar        not null,
 	size           varchar        not null default '',
 	location       varchar        not null default '',
@@ -14768,7 +14806,8 @@ insert into version values
 	('2020-03-27-1-isbot'),
 	('2020-03-24-1-sessions'),
 	('2020-04-06-1-event'),
-	('2020-04-16-1-pwauth');
+	('2020-04-16-1-pwauth'),
+	('2020-04-22-1-campaigns');
 `)
 var Templates = map[string][]byte{
 	"tpl/_backend_bottom.gohtml": []byte(`	</div> {{- /* .page */}}

--- a/pack/pack.go
+++ b/pack/pack.go
@@ -15869,22 +15869,6 @@ closing <code>&lt;/body&gt;</code> tag (but anywhere, such as in the
 				<input type="text" name="link_domain" id="link_domain" value="{{.Site.LinkDomain}}">
 				{{validate "site.link_domain" .Validate}}
 				<span>Your site’s domain, e.g. <em>“www.example.com”</em>, used for linking to the page in the overview.</span>
-
-				<label>{{checkbox .Site.Settings.Public "settings.public"}}
-					Make statistics publicly viewable</label>
-				<span>Anyone can view the statistics without logging in.</span>
-
-				<label for="data_retention">Data retention in days</label>
-				<input type="number" name="settings.data_retention" id="limits_page" value="{{.Site.Settings.DataRetention}}">
-				{{validate "site.settings.data_retention" .Validate}}
-				<span class="help">Pageviews and all associated data will be permanently removed after this many days. Set to <code>0</code> to never delete.</span>
-
-				<label>Ignore IPs</label>
-				<input type="text" name="settings.ignore_ips" value="{{.Site.Settings.IgnoreIPs}}">
-				{{validate "site.settings.ignore_ips" .Validate}}
-				<span>Never count requests coming from these IP addresses.<br>
-					Comma-separated. Only supports exact matches.
-					<a href="#_" id="add-ip">Add current IP</a></span>
 			</fieldset>
 
 			<fieldset>
@@ -15979,6 +15963,37 @@ closing <code>&lt;/body&gt;</code> tag (but anywhere, such as in the
 				</select>
 				{{validate "site.settings.timezone" .Validate}}
 				<span><a href="#_" id="set-local-tz">Set from browser</a></span>
+			</fieldset>
+
+			<fieldset>
+				<legend>Tracking</legend>
+
+				<label>{{checkbox .Site.Settings.Public "settings.public"}}
+					Make statistics publicly viewable</label>
+				<span>Anyone can view the statistics without logging in.</span>
+
+				<label for="data_retention">Data retention in days</label>
+				<input type="number" name="settings.data_retention" id="limits_page" value="{{.Site.Settings.DataRetention}}">
+				{{validate "site.settings.data_retention" .Validate}}
+				<span class="help">Pageviews and all associated data will be permanently removed after this many days. Set to <code>0</code> to never delete.</span>
+
+				<label>Ignore IPs</label>
+				<input type="text" name="settings.ignore_ips" value="{{.Site.Settings.IgnoreIPs}}">
+				{{validate "site.settings.ignore_ips" .Validate}}
+				<span>Never count requests coming from these IP addresses.<br>
+					Comma-separated. Only supports exact matches.
+					<a href="#_" id="add-ip">Add current IP</a></span>
+
+				<label>Campaign parameters</label>
+				<input type="text" name="settings.campaigns" value="{{.Site.Settings.Campaigns}}">
+				{{validate "site.settings.campaigns" .Validate}}
+				<span>
+					List of parameters to count as ‘campaigns’; if set then the
+					value will be set as the referrer, overriding any Referer
+					header; <a href="/code#campaigns">Details</a>.
+					Comma-separated; first match takes precedence.
+				</span>
+
 			</fieldset>
 
 			<div class="flex-break"></div>

--- a/pack/pack.go
+++ b/pack/pack.go
@@ -2148,6 +2148,7 @@ h1 a:after, h2 a:after, h3 a:after, h4 a:after, h5 a:after, h6 a:after {
 			e: !!(vars.event || goatcounter.event),
 			s: [window.screen.width, window.screen.height, (window.devicePixelRatio || 1)],
 			b: is_bot(),
+			q: location.search,
 		}
 
 		var rcb, pcb, tcb  // Save callbacks to apply later.
@@ -15083,6 +15084,11 @@ from the URL:</p>
 {{template "code" .}}
 </code></pre>
 
+<p>Note there is also a <em>Campaign Parameters</em> setting, which is probably easier for
+most people. This is just if you want to get the campaign on only some pages, or
+want to do some more advanced filtering (such as only including your own
+campaigns).</p>
+
 <h2 id="examples">Examples <a href="#examples"></a></h2>
 
 <h3 id="load-only-on-production">Load only on production <a href="#load-only-on-production"></a></h3>
@@ -15306,6 +15312,7 @@ middleware. It supports the following query parameters:</p>
   <li><code>t</code> → <code>title</code></li>
   <li><code>r</code> → <code>referrer</code></li>
   <li><code>s</code> → screen size, as <code>x,y,scaling</code>.</li>
+  <li><code>q</code> → Query parameters, for getting the campaign.</li>
   <li><code>rnd</code> → can be used as a “cache buster” since browsers don’t always obey
 <code>Cache-Control</code>; ignored by the backend.</li>
 </ul>

--- a/public/count.js
+++ b/public/count.js
@@ -16,6 +16,7 @@
 			e: !!(vars.event || goatcounter.event),
 			s: [window.screen.width, window.screen.height, (window.devicePixelRatio || 1)],
 			b: is_bot(),
+			q: location.search,
 		}
 
 		var rcb, pcb, tcb  // Save callbacks to apply later.

--- a/site.go
+++ b/site.go
@@ -99,6 +99,11 @@ func (ss *SiteSettings) Scan(v interface{}) error {
 
 // Defaults sets fields to default values, unless they're already set.
 func (s *Site) Defaults(ctx context.Context) {
+	// New site: Set default settings.
+	if s.ID == 0 {
+		s.Settings.Campaigns = []string{"utm_campaign", "utm_source", "ref"}
+	}
+
 	if s.State == "" {
 		s.State = StateActive
 	}
@@ -118,9 +123,8 @@ func (s *Site) Defaults(ctx context.Context) {
 
 	s.Code = strings.ToLower(s.Code)
 
-	if s.CreatedAt.IsZero() { // New site.
+	if s.CreatedAt.IsZero() {
 		s.CreatedAt = Now()
-		s.Settings.Campaigns = []string{"utm_campaign", "utm_source", "ref"}
 	} else {
 		t := Now()
 		s.UpdatedAt = &t

--- a/site.go
+++ b/site.go
@@ -118,8 +118,9 @@ func (s *Site) Defaults(ctx context.Context) {
 
 	s.Code = strings.ToLower(s.Code)
 
-	if s.CreatedAt.IsZero() {
+	if s.CreatedAt.IsZero() { // New site.
 		s.CreatedAt = Now()
+		s.Settings.Campaigns = []string{"utm_campaign", "utm_source", "ref"}
 	} else {
 		t := Now()
 		s.UpdatedAt = &t

--- a/site.go
+++ b/site.go
@@ -73,6 +73,7 @@ type SiteSettings struct {
 	DataRetention    int                `json:"data_retention"`
 	IgnoreIPs        sqlutil.StringList `json:"ignore_ips"`
 	Timezone         *tz.Zone           `json:"timezone"`
+	Campaigns        sqlutil.StringList `json:"campaigns"`
 	Limits           struct {
 		Page int `json:"page"`
 		Ref  int `json:"ref"`

--- a/tpl/_backend_sitecode.gohtml
+++ b/tpl/_backend_sitecode.gohtml
@@ -199,6 +199,11 @@ from the URL:</p>
 {{template "code" .}}
 </code></pre>
 
+<p>Note there is also a <em>Campaign Parameters</em> setting, which is probably easier for
+most people. This is just if you want to get the campaign on only some pages, or
+want to do some more advanced filtering (such as only including your own
+campaigns).</p>
+
 <h2 id="examples">Examples <a href="#examples"></a></h2>
 
 <h3 id="load-only-on-production">Load only on production <a href="#load-only-on-production"></a></h3>
@@ -422,6 +427,7 @@ middleware. It supports the following query parameters:</p>
   <li><code>t</code> → <code>title</code></li>
   <li><code>r</code> → <code>referrer</code></li>
   <li><code>s</code> → screen size, as <code>x,y,scaling</code>.</li>
+  <li><code>q</code> → Query parameters, for getting the campaign.</li>
   <li><code>rnd</code> → can be used as a “cache buster” since browsers don’t always obey
 <code>Cache-Control</code>; ignored by the backend.</li>
 </ul>

--- a/tpl/_backend_sitecode.markdown
+++ b/tpl/_backend_sitecode.markdown
@@ -127,6 +127,11 @@ from the URL:
     </script>
     {{template "code" .}}
 
+Note there is also a *Campaign Parameters* setting, which is probably easier for
+most people. This is just if you want to get the campaign on only some pages, or
+want to do some more advanced filtering (such as only including your own
+campaigns).
+
 Examples
 --------
 
@@ -336,6 +341,7 @@ middleware. It supports the following query parameters:
 - `t` → `title`
 - `r` → `referrer`
 - `s` → screen size, as `x,y,scaling`.
+- `q` → Query parameters, for getting the campaign.
 - `rnd` → can be used as a “cache buster” since browsers don’t always obey
   `Cache-Control`; ignored by the backend.
 

--- a/tpl/backend_settings.gohtml
+++ b/tpl/backend_settings.gohtml
@@ -19,22 +19,6 @@
 				<input type="text" name="link_domain" id="link_domain" value="{{.Site.LinkDomain}}">
 				{{validate "site.link_domain" .Validate}}
 				<span>Your site’s domain, e.g. <em>“www.example.com”</em>, used for linking to the page in the overview.</span>
-
-				<label>{{checkbox .Site.Settings.Public "settings.public"}}
-					Make statistics publicly viewable</label>
-				<span>Anyone can view the statistics without logging in.</span>
-
-				<label for="data_retention">Data retention in days</label>
-				<input type="number" name="settings.data_retention" id="limits_page" value="{{.Site.Settings.DataRetention}}">
-				{{validate "site.settings.data_retention" .Validate}}
-				<span class="help">Pageviews and all associated data will be permanently removed after this many days. Set to <code>0</code> to never delete.</span>
-
-				<label>Ignore IPs</label>
-				<input type="text" name="settings.ignore_ips" value="{{.Site.Settings.IgnoreIPs}}">
-				{{validate "site.settings.ignore_ips" .Validate}}
-				<span>Never count requests coming from these IP addresses.<br>
-					Comma-separated. Only supports exact matches.
-					<a href="#_" id="add-ip">Add current IP</a></span>
 			</fieldset>
 
 			<fieldset>
@@ -129,6 +113,37 @@
 				</select>
 				{{validate "site.settings.timezone" .Validate}}
 				<span><a href="#_" id="set-local-tz">Set from browser</a></span>
+			</fieldset>
+
+			<fieldset>
+				<legend>Tracking</legend>
+
+				<label>{{checkbox .Site.Settings.Public "settings.public"}}
+					Make statistics publicly viewable</label>
+				<span>Anyone can view the statistics without logging in.</span>
+
+				<label for="data_retention">Data retention in days</label>
+				<input type="number" name="settings.data_retention" id="limits_page" value="{{.Site.Settings.DataRetention}}">
+				{{validate "site.settings.data_retention" .Validate}}
+				<span class="help">Pageviews and all associated data will be permanently removed after this many days. Set to <code>0</code> to never delete.</span>
+
+				<label>Ignore IPs</label>
+				<input type="text" name="settings.ignore_ips" value="{{.Site.Settings.IgnoreIPs}}">
+				{{validate "site.settings.ignore_ips" .Validate}}
+				<span>Never count requests coming from these IP addresses.<br>
+					Comma-separated. Only supports exact matches.
+					<a href="#_" id="add-ip">Add current IP</a></span>
+
+				<label>Campaign parameters</label>
+				<input type="text" name="settings.campaigns" value="{{.Site.Settings.Campaigns}}">
+				{{validate "site.settings.campaigns" .Validate}}
+				<span>
+					List of parameters to count as ‘campaigns’; if set then the
+					value will be set as the referrer, overriding any Referer
+					header; <a href="/code#campaigns">Details</a>.
+					Comma-separated; first match takes precedence.
+				</span>
+
 			</fieldset>
 
 			<div class="flex-break"></div>

--- a/user.go
+++ b/user.go
@@ -18,7 +18,6 @@ import (
 	"zgo.at/utils/sqlutil"
 	"zgo.at/zdb"
 	"zgo.at/zhttp"
-	"zgo.at/zhttp/ctxkey"
 	"zgo.at/zhttp/zmail"
 	"zgo.at/zlog"
 	"zgo.at/zvalidate"
@@ -144,7 +143,8 @@ func (u *User) Insert(ctx context.Context) error {
 
 	if cfg.PgSQL {
 		var nu User
-		err = nu.ByEmail(context.WithValue(ctx, ctxkey.Site, &Site{ID: u.Site}), u.Email)
+		// No site yet when signing up since it's on www.goatcounter.com
+		err = nu.ByEmail(WithSite(ctx, &Site{ID: u.Site}), u.Email)
 		u.ID = nu.ID
 	} else {
 		u.ID, err = res.LastInsertId()


### PR DESCRIPTION
There is now a "campaign parameters" in the settings, allow people to
add parameters to set as the refferer if set (overriding the Referer)
header.

"utm_campaign, utm_source, ref" seems like a good default for this
