### PR TITLE
Allow modifying the endpoint with goatcounter.endpoint

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,2 +1,3 @@
 # Mark as generated so it won't show up in diffs etc.
-pack/*.go  linguist-generated=true
+pack/*.go                     linguist-generated=true
+tpl/_backend_sitecode.gohtml  linguist-generated=true

--- a/cmd/goatcounter/reindex.go
+++ b/cmd/goatcounter/reindex.go
@@ -33,7 +33,7 @@ Avoiding race conditions
   fine to update older data since goatcounter never writes to it, but updating
   the current day may result in:
 
-  1. Goatcounter reads data from DB, processes it, updates the DB.
+  1. GoatCounter reads data from DB, processes it, updates the DB.
   2. In the meanwhile reindex updated the data in the DB.
 
   For this reason, GoatCounter will only update up to yesterday by default; the

--- a/pack/pack.go
+++ b/pack/pack.go
@@ -2196,7 +2196,7 @@ h1 a:after, h2 a:after, h3 a:after, h4 a:after, h5 a:after, h6 a:after {
 			return
 
 		var script   = document.querySelector('script[data-goatcounter]'),
-		    endpoint = window.counter  // Compatibility
+		    endpoint = (window.goatcounter.endpoint || window.counter)  // counter is for compat; don't use.
 		if (script)
 			endpoint = script.dataset.goatcounter
 
@@ -14847,6 +14847,7 @@ var Templates = map[string][]byte{
       <li><a href="#image-based-tracking-without-javascript" id="markdown-toc-image-based-tracking-without-javascript">Image-based tracking without JavaScript</a></li>
       <li><a href="#tracking-from-backend-middleware" id="markdown-toc-tracking-from-backend-middleware">Tracking from backend middleware</a></li>
       <li><a href="#location-of-countjs" id="markdown-toc-location-of-countjs">Location of count.js</a></li>
+      <li><a href="#setting-the-endpoint-in-javascript" id="markdown-toc-setting-the-endpoint-in-javascript">Setting the endpoint in JavaScript</a></li>
     </ul>
   </li>
 </ul>
@@ -14983,10 +14984,14 @@ the parameter doesn’t exist. This is useful if you want to get the <code>refer
 from the URL:</p>
 
 <pre><code>&lt;script&gt;
-    referrer: function() {
-        return goatcounter.get_query('ref') || goatcounter.get_query('utm_source') || document.referrer
+    window.goatcounter = {
+        referrer: function() {
+            return goatcounter.get_query('ref') ||
+                goatcounter.get_query('utm_campaign') ||
+                goatcounter.get_query('utm_source') ||
+                document.referrer
+        },
     }
-}
 &lt;/script&gt;
 {{template "code" .}}
 </code></pre>
@@ -15191,6 +15196,42 @@ directly inside <code>&lt;script&gt;</code> tags. You won’t get any new featur
 updates, but the <code>/count</code> endpoint is guaranteed to remain compatible so it
 should never break (any future incompatible changes will be a different
 endpoint, such as <code>/count/v2</code>).</p>
+
+<p>Be sure to include the <code>data-goatcounter</code> attribute on the script tag, so
+GoatCounter knows where to send the pageviews to:</p>
+
+<pre><code>&lt;script data-goatcounter="{{.Site.URL}}/count"&gt;
+    // [.. contents of count.js ..]
+&lt;/script&gt;
+</code></pre>
+
+<h3 id="setting-the-endpoint-in-javascript">Setting the endpoint in JavaScript <a href="#setting-the-endpoint-in-javascript"></a></h3>
+<p>Normally GoatCounter gets the endpoint to send pageviews to from the
+<code>data-goatcounter</code> attribute on the <code>&lt;script&gt;</code> tag, but in some cases you may
+want to modify that in JavaScript; you can use <code>goatcounter.endpoint</code> for that.</p>
+
+<p>For example, to send to different sites depending on the current hostname:</p>
+
+<pre><code>&lt;script&gt;
+    var code = '';
+    switch (location.hostname) {
+    case 'example.com':
+        code = 'a'
+        break
+    case 'example.org':
+        code = 'b'
+        break
+    default:
+        code = 'c'
+    }
+    window.goatcounter = {
+        endpoint: 'https://' + code + '.goatcounter.com/count',
+    }
+&lt;/script&gt;
+&lt;script async src="//{{.CountDomain}}/count.js"&gt;&lt;/script&gt;
+</code></pre>
+
+<p>Note that <code>data-goatcounter</code> will always override any <code>goatcounter.endpoint</code>.</p>
 
 {{end}} {{/* if eq .Path "/settings" */}}
 `),

--- a/pack/pack.go
+++ b/pack/pack.go
@@ -2242,13 +2242,18 @@ h1 a:after, h2 a:after, h3 a:after, h4 a:after, h5 a:after, h6 a:after {
 		})
 	}
 
-	if (!goatcounter.no_events)
-		goatcounter.bind_events()
-	if (!goatcounter.no_onload)
-		if (document.body === null)
-			document.addEventListener('DOMContentLoaded', function() { goatcounter.count() }, false)
-		else
+	if (!goatcounter.no_onload) {
+		var go = function() {
 			goatcounter.count()
+			if (!goatcounter.no_events)
+				goatcounter.bind_events()
+		}
+
+		if (document.body === null)
+			document.addEventListener('DOMContentLoaded', function() { go() }, false)
+		else
+			go()
+	}
 })();
 `),
 	"public/favicon/android-chrome-192x192.png": func() []byte {
@@ -14900,7 +14905,7 @@ are supported:</p>
   <tbody>
     <tr>
       <td style="text-align: left"><code>no_onload</code></td>
-      <td style="text-align: left">Don’t do anything on page load. If you want to call <code>count()</code> manually.</td>
+      <td style="text-align: left">Don’t do anything on page load. If you want to call <code>count()</code> manually. Also won’t bind events.</td>
     </tr>
     <tr>
       <td style="text-align: left"><code>no_events</code></td>

--- a/public/count.js
+++ b/public/count.js
@@ -77,7 +77,7 @@
 			return
 
 		var script   = document.querySelector('script[data-goatcounter]'),
-		    endpoint = window.counter  // Compatibility
+		    endpoint = (window.goatcounter.endpoint || window.counter)  // counter is for compat; don't use.
 		if (script)
 			endpoint = script.dataset.goatcounter
 

--- a/public/count.js
+++ b/public/count.js
@@ -123,11 +123,16 @@
 		})
 	}
 
-	if (!goatcounter.no_events)
-		goatcounter.bind_events()
-	if (!goatcounter.no_onload)
-		if (document.body === null)
-			document.addEventListener('DOMContentLoaded', function() { goatcounter.count() }, false)
-		else
+	if (!goatcounter.no_onload) {
+		var go = function() {
 			goatcounter.count()
+			if (!goatcounter.no_events)
+				goatcounter.bind_events()
+		}
+
+		if (document.body === null)
+			document.addEventListener('DOMContentLoaded', function() { go() }, false)
+		else
+			go()
+	}
 })();

--- a/tpl/_backend_sitecode.gohtml
+++ b/tpl/_backend_sitecode.gohtml
@@ -41,6 +41,7 @@
       <li><a href="#image-based-tracking-without-javascript" id="markdown-toc-image-based-tracking-without-javascript">Image-based tracking without JavaScript</a></li>
       <li><a href="#tracking-from-backend-middleware" id="markdown-toc-tracking-from-backend-middleware">Tracking from backend middleware</a></li>
       <li><a href="#location-of-countjs" id="markdown-toc-location-of-countjs">Location of count.js</a></li>
+      <li><a href="#setting-the-endpoint-in-javascript" id="markdown-toc-setting-the-endpoint-in-javascript">Setting the endpoint in JavaScript</a></li>
     </ul>
   </li>
 </ul>
@@ -177,10 +178,14 @@ the parameter doesn’t exist. This is useful if you want to get the <code>refer
 from the URL:</p>
 
 <pre><code>&lt;script&gt;
-    referrer: function() {
-        return goatcounter.get_query('ref') || goatcounter.get_query('utm_source') || document.referrer
+    window.goatcounter = {
+        referrer: function() {
+            return goatcounter.get_query('ref') ||
+                goatcounter.get_query('utm_campaign') ||
+                goatcounter.get_query('utm_source') ||
+                document.referrer
+        },
     }
-}
 &lt;/script&gt;
 {{template "code" .}}
 </code></pre>
@@ -385,5 +390,41 @@ directly inside <code>&lt;script&gt;</code> tags. You won’t get any new featur
 updates, but the <code>/count</code> endpoint is guaranteed to remain compatible so it
 should never break (any future incompatible changes will be a different
 endpoint, such as <code>/count/v2</code>).</p>
+
+<p>Be sure to include the <code>data-goatcounter</code> attribute on the script tag, so
+GoatCounter knows where to send the pageviews to:</p>
+
+<pre><code>&lt;script data-goatcounter="{{.Site.URL}}/count"&gt;
+    // [.. contents of count.js ..]
+&lt;/script&gt;
+</code></pre>
+
+<h3 id="setting-the-endpoint-in-javascript">Setting the endpoint in JavaScript <a href="#setting-the-endpoint-in-javascript"></a></h3>
+<p>Normally GoatCounter gets the endpoint to send pageviews to from the
+<code>data-goatcounter</code> attribute on the <code>&lt;script&gt;</code> tag, but in some cases you may
+want to modify that in JavaScript; you can use <code>goatcounter.endpoint</code> for that.</p>
+
+<p>For example, to send to different sites depending on the current hostname:</p>
+
+<pre><code>&lt;script&gt;
+    var code = '';
+    switch (location.hostname) {
+    case 'example.com':
+        code = 'a'
+        break
+    case 'example.org':
+        code = 'b'
+        break
+    default:
+        code = 'c'
+    }
+    window.goatcounter = {
+        endpoint: 'https://' + code + '.goatcounter.com/count',
+    }
+&lt;/script&gt;
+&lt;script async src="//{{.CountDomain}}/count.js"&gt;&lt;/script&gt;
+</code></pre>
+
+<p>Note that <code>data-goatcounter</code> will always override any <code>goatcounter.endpoint</code>.</p>
 
 {{end}} {{/* if eq .Path "/settings" */}}

--- a/tpl/_backend_sitecode.gohtml
+++ b/tpl/_backend_sitecode.gohtml
@@ -94,7 +94,7 @@ are supported:</p>
   <tbody>
     <tr>
       <td style="text-align: left"><code>no_onload</code></td>
-      <td style="text-align: left">Don’t do anything on page load. If you want to call <code>count()</code> manually.</td>
+      <td style="text-align: left">Don’t do anything on page load. If you want to call <code>count()</code> manually. Also won’t bind events.</td>
     </tr>
     <tr>
       <td style="text-align: left"><code>no_events</code></td>

--- a/tpl/_backend_sitecode.gohtml
+++ b/tpl/_backend_sitecode.gohtml
@@ -40,7 +40,7 @@
   <li><a href="#advanced-integrations" id="markdown-toc-advanced-integrations">Advanced integrations</a>    <ul>
       <li><a href="#image-based-tracking-without-javascript" id="markdown-toc-image-based-tracking-without-javascript">Image-based tracking without JavaScript</a></li>
       <li><a href="#tracking-from-backend-middleware" id="markdown-toc-tracking-from-backend-middleware">Tracking from backend middleware</a></li>
-      <li><a href="#location-of-countjs" id="markdown-toc-location-of-countjs">Location of count.js</a></li>
+      <li><a href="#location-of-countjs-and-loading-it-locally" id="markdown-toc-location-of-countjs-and-loading-it-locally">Location of count.js and loading it locally</a></li>
       <li><a href="#setting-the-endpoint-in-javascript" id="markdown-toc-setting-the-endpoint-in-javascript">Setting the endpoint in JavaScript</a></li>
     </ul>
   </li>
@@ -72,11 +72,15 @@ is used if <code>data-goatcounter-title</code> is empty. There is no default for
 referrer.</p>
 
 <h2 id="content-security-policy">Content security policy <a href="#content-security-policy"></a></h2>
-<p>You’ll need the following if you use a <code>Content-Security-Policy</code>:</p>
+<p>You’ll need to add the following if you use a <code>Content-Security-Policy</code>:</p>
 
 <pre><code>script-src  https://{{.CountDomain}}
 img-src     {{.Site.URL}}/count
 </code></pre>
+
+<p>The <code>script-src</code> is needed to load the <code>count.js</code> script, and the <code>img-src</code> is
+needed to send pageviews to GoatCounter (which are loaded with a “tracking
+pixel”).</p>
 
 <h2 id="customizing">Customizing <a href="#customizing"></a></h2>
 <p>Customisation is done with the <code>window.goatcounter</code> object; the following keys
@@ -103,6 +107,10 @@ are supported:</p>
     <tr>
       <td style="text-align: left"><code>allow_local</code></td>
       <td style="text-align: left">Allow requests from local addresses (<code>localhost</code>, <code>192.168.0.0</code>, etc.) for testing the integration locally.</td>
+    </tr>
+    <tr>
+      <td style="text-align: left"><code>endpoint</code></td>
+      <td style="text-align: left">Customize the endpoint for sending pageviews to; see <a href="#setting-the-endpoint-in-javascript">Setting the endpoint in JavaScript </a>.</td>
     </tr>
   </tbody>
 </table>
@@ -151,8 +159,8 @@ described in the Data section above, and will be merged in to the global
 <code>window.goatcounter</code>, taking precedence.</p>
 
 <p>Be aware that the script is loaded with <code>async</code> by default, so <code>count()</code> may not
-yet be available on click events and the like. To solve this, use
-<code>setInterval()</code> to wait until it’s available:</p>
+yet be available on click events and the like. Use <code>setInterval()</code> to wait until
+it’s available:</p>
 
 <pre><code>elem.addEventListener('click', function() {
     var t = setInterval(function() {
@@ -169,8 +177,8 @@ about this if you call <code>count()</code> manually.</p>
 
 <h4 id="bindevents"><code>bind_events()</code> <a href="#bindevents"></a></h4>
 <p>Bind a click event to every element with <code>data-goatcounter-click</code>. Called on
-page load unless <code>no_events</code> is set. You may need to call this manually if you
-insert elements after the page loads.</p>
+page load unless <code>no_onload</code> or <code>no_events</code> is set. You may need to call this
+manually if you insert elements after the page loads.</p>
 
 <h4 id="getqueryname"><code>get_query(name)</code> <a href="#getqueryname"></a></h4>
 <p>Get a single query parameter from the current page’s URL; returns <code>undefined</code> if
@@ -205,7 +213,7 @@ from the URL:</p>
 </code></pre>
 
 <p>Note that <a href="https://github.com/zgoat/goatcounter/blob/9525be9/public/count.js#L69-L72">request from localhost are already
-ignored</a></p>
+ignored</a>.</p>
 
 <h3 id="skip-own-views">Skip own views <a href="#skip-own-views"></a></h3>
 <p>You can use the same technique as a client-side way to skip loading from your
@@ -227,6 +235,7 @@ own browser:</p>
 
 <pre><code>&lt;script&gt;
     window.goatcounter = {
+        // The passed value is the default.
         path: function(p) {
             // Don't track the home page.
             if (p === '/')
@@ -241,9 +250,9 @@ own browser:</p>
 </code></pre>
 
 <h3 id="multiple-domains">Multiple domains <a href="#multiple-domains"></a></h3>
-<p>Right now GoatCounter doesn’t store the domain a pageview belongs to. If you add
+<p>GoatCounter doesn’t store the domain a pageview belongs to; if you add
 GoatCounter to several (sub)domain then there’s no way to distinguish between
-requests to <code>a.example.com/path</code> and <code>b.example.com/path</code>, as they’re both
+requests to <code>a.example.com/path</code> and <code>b.example.com/path</code> as they’re both
 recorded as <code>/path</code>.</p>
 
 <p>This might be improved at some point in the future; the options right now are:</p>
@@ -255,8 +264,8 @@ separate site which inherits the user, login, plan, etc. You will need to use
 a different site code for every (sub)domain.</p>
   </li>
   <li>
-    <p>If you want everything in a single overview on a single site, then you can
-add the domain to the path, instead of just sending the path:</p>
+    <p>If you want everything in a single overview then you can add the domain to
+the path, instead of just sending the path:</p>
 
     <pre><code>&lt;script&gt;
     window.goatcounter = {
@@ -267,8 +276,8 @@ add the domain to the path, instead of just sending the path:</p>
 </code></pre>
 
     <p>For subdomains it it might be more useful to just add the first domain label
-instead of the full domain here, depending on taste, or perhaps just a short
-static string.</p>
+instead of the full domain here, or perhaps just a short static string
+identifying the source.</p>
   </li>
 </ol>
 
@@ -280,11 +289,10 @@ easiest way to ignore extraneous query parameters:</p>
 </code></pre>
 
 <p>The <code>href</code> can also be relative (e.g. <code>/path.html</code>. Be sure to understand the
-potential SEO effects before adding a canonical URL! If you use query parameters
-for navigation then you probably <em>don’t</em> want it.</p>
+potential SEO effects before adding a canonical URL; if you use query parameters
+for navigation then you probably <em>don’t</em> want to do this.</p>
 
-<p>Alternatively you can send a custom <code>path</code> without the query
-parameters:</p>
+<p>Alternatively you can send a custom <code>path</code> without the query parameters:</p>
 
 <pre><code>&lt;script&gt;
     window.goatcounter = {
@@ -294,8 +302,15 @@ parameters:</p>
 {{template "code" .}}
 </code></pre>
 
+<p>You can add individual query parameters with <code>get_query()</code>:</p>
+
+<pre><code>window.goatcounter = {
+    path: (location.pathname + '?page=' + get_query('page')) || '/',
+}
+</code></pre>
+
 <h3 id="spa">SPA <a href="#spa"></a></h3>
-<p>Custom <code>count()</code> example for hooking in to an SPA:</p>
+<p>Custom <code>count()</code> example for hooking in to an SPA nagivating by <code>#</code>:</p>
 
 <pre><code>&lt;script&gt;
     window.goatcounter = {no_onload: true}
@@ -323,19 +338,19 @@ For example:</p>
 </code></pre>
 
 <p>Note that the <code>path</code> doubles as the event name. There is currently no real way
-to record the pathname with the event, although you can send it as part of the
-event name with something like:</p>
+to record the path with the event, although you can send it as part of the event
+name:</p>
 
 <pre><code>window.goatcounter.count({
-    path:  function(p) { p + '_banana' },
+    path:  function(p) { 'click-banana-' + p },
     event: true,
 })
 </code></pre>
 
-<p>The callback will have the regular <code>path</code> passed to it, and you can append an
-event name there; you can also use <code>window.location.pathname</code> directly; the
-biggest difference with the passed value is that <code>&lt;link rel="canonical"&gt;</code> is
-taken in to account.</p>
+<p>The callback will have the regular <code>path</code> passed to it, and you can add an event
+name there; you can also use <code>window.location.pathname</code> directly; the biggest
+difference with the passed value is that <code>&lt;link rel="canonical"&gt;</code> is taken in to
+account.</p>
 
 <h2 id="advanced-integrations">Advanced integrations <a href="#advanced-integrations"></a></h2>
 
@@ -346,9 +361,10 @@ an image on your site:</p>
 <pre><code>&lt;img src="{{.Site.URL}}/count?p=/test-img"&gt;
 </code></pre>
 
-<p>This won’t allow recording the referral or screen size though, and may also
-increase the number of bot requests (although we do our best to filter this
-out).</p>
+<p>This won’t allow recording the referral or screen size, and may also increase
+the number of bot requests (we do our best to filter this out, but it’s hard to
+get all of them, since many spam scrapers and such disguise themselves as
+regular browsers).</p>
 
 <p>Wrap in a <code>&lt;noscript&gt;</code> tag to use this only for people without JavaScript.</p>
 
@@ -369,21 +385,19 @@ middleware. It supports the following query parameters:</p>
 <p>The <code>User-Agent</code> header and remote address are used for the browser and
 location.</p>
 
-<p>Calling it from the middleware or as will probably result in more bot requests.
-GoatCounter does its best to filter this out, but it’s impossible to do this
-100% reliably.</p>
+<p>Calling it from the middleware will probably result in more bot requests, as
+mentioned in the previous section.</p>
 
-<h3 id="location-of-countjs">Location of count.js <a href="#location-of-countjs"></a></h3>
-<p>You can load the <code>count.js</code> script anywhere, but it’s recommended to load it
-just before the closing <code>&lt;/body&gt;</code> tag if possible.</p>
+<h3 id="location-of-countjs-and-loading-it-locally">Location of count.js and loading it locally <a href="#location-of-countjs-and-loading-it-locally"></a></h3>
+<p>You can load the <code>count.js</code> script anywhere on your page, but it’s recommended
+to load it just before the closing <code>&lt;/body&gt;</code> tag if possible.</p>
 
 <p>The reason for this is that downloading the <code>count.js</code> script will take up some
-bandwidth which could be better used for the actual JS/CSS used to render the
+bandwidth which could be better used for the actual assets needed to render the
 site. The script is quite small (about 2K), so it’s not a huge difference, but
-might as well put it in the best possible location if possible.</p>
-
-<p>If your CMS makes it hard to insert a JavaScript tag there, then just insert it
-in the <code>&lt;head&gt;</code>, or anywhere in the <code>&lt;body&gt;</code>.</p>
+might as well put it in the best location if possible. Just insert it in the
+<code>&lt;head&gt;</code> or anywhere in the <code>&lt;body&gt;</code> if your CMS doesn’t have an option to add
+it there.</p>
 
 <p>You can also host the <code>count.js</code> script yourself, or include it in your page
 directly inside <code>&lt;script&gt;</code> tags. You won’t get any new features or other
@@ -391,10 +405,18 @@ updates, but the <code>/count</code> endpoint is guaranteed to remain compatible
 should never break (any future incompatible changes will be a different
 endpoint, such as <code>/count/v2</code>).</p>
 
-<p>Be sure to include the <code>data-goatcounter</code> attribute on the script tag, so
-GoatCounter knows where to send the pageviews to:</p>
+<p>Be sure to include the <code>data-goatcounter</code> attribute on the script tag or set
+<code>goatcounter.endpoint</code> so GoatCounter knows where to send the pageviews to:</p>
 
 <pre><code>&lt;script data-goatcounter="{{.Site.URL}}/count"&gt;
+    // [.. contents of count.js ..]
+&lt;/script&gt;
+
+// or:
+
+&lt;script&gt;
+    window.goatcounter = {endpoint: '{{.Site.URL}}/count'}
+
     // [.. contents of count.js ..]
 &lt;/script&gt;
 </code></pre>

--- a/tpl/_backend_sitecode.markdown
+++ b/tpl/_backend_sitecode.markdown
@@ -111,10 +111,14 @@ the parameter doesn’t exist. This is useful if you want to get the `referrer`
 from the URL:
 
     <script>
-        referrer: function() {
-            return goatcounter.get_query('ref') || goatcounter.get_query('utm_source') || document.referrer
+        window.goatcounter = {
+            referrer: function() {
+                return goatcounter.get_query('ref') ||
+                    goatcounter.get_query('utm_campaign') ||
+                    goatcounter.get_query('utm_source') ||
+                    document.referrer
+            },
         }
-    }
     </script>
     {{template "code" .}}
 
@@ -303,5 +307,39 @@ directly inside `<script>` tags. You won’t get any new features or other
 updates, but the `/count` endpoint is guaranteed to remain compatible so it
 should never break (any future incompatible changes will be a different
 endpoint, such as `/count/v2`).
+
+Be sure to include the `data-goatcounter` attribute on the script tag, so
+GoatCounter knows where to send the pageviews to:
+
+    <script data-goatcounter="{{.Site.URL}}/count">
+        // [.. contents of count.js ..]
+    </script>
+
+### Setting the endpoint in JavaScript
+Normally GoatCounter gets the endpoint to send pageviews to from the
+`data-goatcounter` attribute on the `<script>` tag, but in some cases you may
+want to modify that in JavaScript; you can use `goatcounter.endpoint` for that.
+
+For example, to send to different sites depending on the current hostname:
+
+    <script>
+        var code = '';
+        switch (location.hostname) {
+        case 'example.com':
+            code = 'a'
+            break
+        case 'example.org':
+            code = 'b'
+            break
+        default:
+            code = 'c'
+        }
+        window.goatcounter = {
+            endpoint: 'https://' + code + '.goatcounter.com/count',
+        }
+    </script>
+    <script async src="//{{.CountDomain}}/count.js"></script>
+
+Note that `data-goatcounter` will always override any `goatcounter.endpoint`.
 
 {{end}} {{/* if eq .Path "/settings" */}}

--- a/tpl/_backend_sitecode.markdown
+++ b/tpl/_backend_sitecode.markdown
@@ -56,7 +56,7 @@ are supported:
 {:class="reftable"}
 | Setting       | Description                                                                                                 |
 | :------       | :----------                                                                                                 |
-| `no_onload`   | Don’t do anything on page load. If you want to call `count()` manually.                                     |
+| `no_onload`   | Don’t do anything on page load. If you want to call `count()` manually. Also won’t bind events.             |
 | `no_events`   | Don’t bind click events.                                                                                    |
 | `allow_local` | Allow requests from local addresses (`localhost`, `192.168.0.0`, etc.) for testing the integration locally. |
 

--- a/tpl/_backend_sitecode.markdown
+++ b/tpl/_backend_sitecode.markdown
@@ -41,10 +41,14 @@ referrer.
 
 Content security policy
 -----------------------
-You’ll need the following if you use a `Content-Security-Policy`:
+You’ll need to add the following if you use a `Content-Security-Policy`:
 
     script-src  https://{{.CountDomain}}
     img-src     {{.Site.URL}}/count
+
+The `script-src` is needed to load the `count.js` script, and the `img-src` is
+needed to send pageviews to GoatCounter (which are loaded with a “tracking
+pixel”).
 
 Customizing
 -----------
@@ -59,6 +63,7 @@ are supported:
 | `no_onload`   | Don’t do anything on page load. If you want to call `count()` manually. Also won’t bind events.             |
 | `no_events`   | Don’t bind click events.                                                                                    |
 | `allow_local` | Allow requests from local addresses (`localhost`, `192.168.0.0`, etc.) for testing the integration locally. |
+| `endpoint`    | Customize the endpoint for sending pageviews to; see [Setting the endpoint in JavaScript ](#setting-the-endpoint-in-javascript). |
 
 ### Data parameters
 You can customize the data sent to GoatCounter; the default value will be used
@@ -85,8 +90,8 @@ described in the Data section above, and will be merged in to the global
 `window.goatcounter`, taking precedence.
 
 Be aware that the script is loaded with `async` by default, so `count()` may not
-yet be available on click events and the like. To solve this, use
-`setInterval()` to wait until it’s available:
+yet be available on click events and the like. Use `setInterval()` to wait until
+it’s available:
 
     elem.addEventListener('click', function() {
         var t = setInterval(function() {
@@ -102,8 +107,8 @@ about this if you call `count()` manually.
 
 #### `bind_events()`
 Bind a click event to every element with `data-goatcounter-click`. Called on
-page load unless `no_events` is set. You may need to call this manually if you
-insert elements after the page loads.
+page load unless `no_onload` or `no_events` is set. You may need to call this
+manually if you insert elements after the page loads.
 
 #### `get_query(name)`
 Get a single query parameter from the current page’s URL; returns `undefined` if
@@ -137,7 +142,7 @@ You can check `location.host` if you want to load GoatCounter only on
     {{template "code" .}}
 
 Note that [request from localhost are already
-ignored](https://github.com/zgoat/goatcounter/blob/9525be9/public/count.js#L69-L72)
+ignored](https://github.com/zgoat/goatcounter/blob/9525be9/public/count.js#L69-L72).
 
 ### Skip own views
 You can use the same technique as a client-side way to skip loading from your
@@ -158,6 +163,7 @@ A basic example with some custom logic for `path`:
 
     <script>
         window.goatcounter = {
+            // The passed value is the default.
             path: function(p) {
                 // Don't track the home page.
                 if (p === '/')
@@ -171,9 +177,9 @@ A basic example with some custom logic for `path`:
     {{template "code" .}}
 
 ### Multiple domains
-Right now GoatCounter doesn’t store the domain a pageview belongs to. If you add
+GoatCounter doesn’t store the domain a pageview belongs to; if you add
 GoatCounter to several (sub)domain then there’s no way to distinguish between
-requests to `a.example.com/path` and `b.example.com/path`, as they’re both
+requests to `a.example.com/path` and `b.example.com/path` as they’re both
 recorded as `/path`.
 
 This might be improved at some point in the future; the options right now are:
@@ -182,8 +188,8 @@ This might be improved at some point in the future; the options right now are:
    separate site which inherits the user, login, plan, etc. You will need to use
    a different site code for every (sub)domain.
 
-2. If you want everything in a single overview on a single site, then you can
-   add the domain to the path, instead of just sending the path:
+2. If you want everything in a single overview then you can add the domain to
+   the path, instead of just sending the path:
 
        <script>
            window.goatcounter = {
@@ -193,8 +199,8 @@ This might be improved at some point in the future; the options right now are:
        {{template "code" .}}
 
    For subdomains it it might be more useful to just add the first domain label
-   instead of the full domain here, depending on taste, or perhaps just a short
-   static string.
+   instead of the full domain here, or perhaps just a short static string
+   identifying the source.
 
 ### Ignore query parameters in path
 The value of `<link rel="canonical">` will be used automatically, and is the
@@ -203,11 +209,10 @@ easiest way to ignore extraneous query parameters:
     <link rel="canonical" href="https://example.com/path.html">
 
 The `href` can also be relative (e.g. `/path.html`. Be sure to understand the
-potential SEO effects before adding a canonical URL! If you use query parameters
-for navigation then you probably *don’t* want it.
+potential SEO effects before adding a canonical URL; if you use query parameters
+for navigation then you probably *don’t* want to do this.
 
-Alternatively you can send a custom `path` without the query
-parameters:
+Alternatively you can send a custom `path` without the query parameters:
 
     <script>
         window.goatcounter = {
@@ -216,8 +221,14 @@ parameters:
     </script>
     {{template "code" .}}
 
+You can add individual query parameters with `get_query()`:
+
+    window.goatcounter = {
+        path: (location.pathname + '?page=' + get_query('page')) || '/',
+    }
+
 ### SPA
-Custom `count()` example for hooking in to an SPA:
+Custom `count()` example for hooking in to an SPA nagivating by `#`:
 
     <script>
         window.goatcounter = {no_onload: true}
@@ -243,18 +254,18 @@ For example:
     })
 
 Note that the `path` doubles as the event name. There is currently no real way
-to record the pathname with the event, although you can send it as part of the
-event name with something like:
+to record the path with the event, although you can send it as part of the event
+name:
 
     window.goatcounter.count({
-        path:  function(p) { p + '_banana' },
+        path:  function(p) { 'click-banana-' + p },
         event: true,
     })
 
-The callback will have the regular `path` passed to it, and you can append an
-event name there; you can also use `window.location.pathname` directly; the
-biggest difference with the passed value is that `<link rel="canonical">` is
-taken in to account.
+The callback will have the regular `path` passed to it, and you can add an event
+name there; you can also use `window.location.pathname` directly; the biggest
+difference with the passed value is that `<link rel="canonical">` is taken in to
+account.
 
 Advanced integrations
 ---------------------
@@ -265,9 +276,10 @@ an image on your site:
 
     <img src="{{.Site.URL}}/count?p=/test-img">
 
-This won’t allow recording the referral or screen size though, and may also
-increase the number of bot requests (although we do our best to filter this
-out).
+This won’t allow recording the referral or screen size, and may also increase
+the number of bot requests (we do our best to filter this out, but it’s hard to
+get all of them, since many spam scrapers and such disguise themselves as
+regular browsers).
 
 Wrap in a `<noscript>` tag to use this only for people without JavaScript.
 
@@ -286,21 +298,19 @@ middleware. It supports the following query parameters:
 The `User-Agent` header and remote address are used for the browser and
 location.
 
-Calling it from the middleware or as will probably result in more bot requests.
-GoatCounter does its best to filter this out, but it’s impossible to do this
-100% reliably.
+Calling it from the middleware will probably result in more bot requests, as
+mentioned in the previous section.
 
-### Location of count.js
-You can load the `count.js` script anywhere, but it’s recommended to load it
-just before the closing `</body>` tag if possible.
+### Location of count.js and loading it locally
+You can load the `count.js` script anywhere on your page, but it’s recommended
+to load it just before the closing `</body>` tag if possible.
 
 The reason for this is that downloading the `count.js` script will take up some
-bandwidth which could be better used for the actual JS/CSS used to render the
+bandwidth which could be better used for the actual assets needed to render the
 site. The script is quite small (about 2K), so it’s not a huge difference, but
-might as well put it in the best possible location if possible.
-
-If your CMS makes it hard to insert a JavaScript tag there, then just insert it
-in the `<head>`, or anywhere in the `<body>`.
+might as well put it in the best location if possible. Just insert it in the
+`<head>` or anywhere in the `<body>` if your CMS doesn’t have an option to add
+it there.
 
 You can also host the `count.js` script yourself, or include it in your page
 directly inside `<script>` tags. You won’t get any new features or other
@@ -308,10 +318,18 @@ updates, but the `/count` endpoint is guaranteed to remain compatible so it
 should never break (any future incompatible changes will be a different
 endpoint, such as `/count/v2`).
 
-Be sure to include the `data-goatcounter` attribute on the script tag, so
-GoatCounter knows where to send the pageviews to:
+Be sure to include the `data-goatcounter` attribute on the script tag or set
+`goatcounter.endpoint` so GoatCounter knows where to send the pageviews to:
 
     <script data-goatcounter="{{.Site.URL}}/count">
+        // [.. contents of count.js ..]
+    </script>
+
+    // or:
+
+    <script>
+        window.goatcounter = {endpoint: '{{.Site.URL}}/count'}
+
         // [.. contents of count.js ..]
     </script>
 

--- a/tpl/_backend_top.gohtml
+++ b/tpl/_backend_top.gohtml
@@ -11,7 +11,7 @@
 
 <body>
 	<noscript>
-		<p>Goatcounter requires JavaScript enabled to function well; please allow JavaScript to run from {{.StaticDomain}}.</p>
+		<p>GoatCounter requires JavaScript enabled to function well; please allow JavaScript to run from {{.StaticDomain}}.</p>
 		<!--
 		<p><small>For a rationale, see: <a href="https://arp242.net/noscript.html">https://arp242.net/noscript.html</a></small></p>
 		-->

--- a/tpl/backend_settings.gohtml
+++ b/tpl/backend_settings.gohtml
@@ -65,7 +65,7 @@
 							<a href="https://www.goatcounter.com/help#custom-domain" target="_blank">Detailed instructions</a>.
 						{{end}}</span>
 				{{else}}
-					<label for="cname">Goatcounter domain</label>
+					<label for="cname">GoatCounter domain</label>
 					<input type="text" name="cname" id="cname" value="{{if .Site.Cname}}{{.Site.Cname}}{{end}}">
 					<span>You GoatCounter installation’s domain, e.g. <em>“stats.example.com”</em>.</span>
 				{{end}}
@@ -281,7 +281,7 @@
 
 			{{if and (not .Site.Parent) .Saas}}
 				<label for="reason">It would be appreciated if you could let me know
-					if there's anything in particular you're missing in Goatcounter,
+					if there's anything in particular you're missing in GoatCounter,
 					or any other reasons you have for wanting to delete your
 					account. This is entirely optional.</label><br>
 				<textarea id="reason" name="reason" placeholder="Optional reason for deletion"></textarea><br><br>

--- a/tpl/help.gohtml
+++ b/tpl/help.gohtml
@@ -18,7 +18,7 @@
 	<dt id="dnt">How is the <code>Do-Not-Track</code> header handled? <a href="#dnt">§</a></dt>
 	<dd>It’s ignored for several reasons: it’s effectively abandoned with a low
 		adoption rate, mostly intended for persistent cross-site tracking (which
-		Goatcounter doesn’t do), and I feel there are some fundamental concerns
+		GoatCounter doesn’t do), and I feel there are some fundamental concerns
 		with the approach. See
 		<a href="https://www.arp242.net/dnt.html" target="_blank" rel="noopener">Why GoatCounter ignores Do Not Track</a>
 		for a more in-depth explanation.

--- a/user.go
+++ b/user.go
@@ -362,7 +362,7 @@ func (u *User) SendLoginMail(ctx context.Context, site *Site) {
 		err := zmail.Send("Your login URL",
 			mail.Address{Name: "GoatCounter login", Address: cfg.LoginFrom},
 			[]mail.Address{{Name: u.Name, Address: u.Email}},
-			fmt.Sprintf("Hi there,\n\nYour login URL for Goatcounter is:\n\n  %s/user/login/%s\n\nGo to it to log in. This key is valid for one hour and can be used only once.\n",
+			fmt.Sprintf("Hi there,\n\nYour login URL for GoatCounter is:\n\n  %s/user/login/%s\n\nGo to it to log in. This key is valid for one hour and can be used only once.\n",
 				site.URL(), *u.LoginRequest))
 		if err != nil {
 			zlog.Errorf("zmail: %s", err)


### PR DESCRIPTION
Previously that was already possible with window.counter, but a random
global like that is rather meh.

Still support the window.counter, since some older sites use that before
I added the data-goatcounter attribute.