### PR TITLE
js/bind_events: send referrer instead of referral

### DIFF
--- a/public/count.js
+++ b/public/count.js
@@ -118,7 +118,7 @@
 					event:    true,
 					path:     (elem.dataset.goatcounterClick || elem.name || elem.id || ''),
 					title:    (elem.dataset.goatcounterTitle || elem.title || (elem.innerHTML || '').substr(0, 200) || ''),
-					referral: (elem.dataset.goatcounterReferral || ''),
+					referrer: (elem.dataset.goatcounterReferrer || elem.dataset.goatcounterReferral || ''),
 				})
 			}
 			elem.addEventListener('click', send, false)

--- a/tpl/_backend_sitecode.gohtml
+++ b/tpl/_backend_sitecode.gohtml
@@ -58,13 +58,13 @@ link as <code>ext-example.com</code>:</p>
 <p>The <code>name</code> or <code>id</code> attribute will be used if <code>data-goatcounter-click</code> is empty,
 in that order.</p>
 
-<p>You can use <code>data-goatcounter-title</code> and <code>data-goatcounter-referral</code> to set the
-title and/or referral:</p>
+<p>You can use <code>data-goatcounter-title</code> and <code>data-goatcounter-referrer</code> to set the
+title and/or referrer:</p>
 
 <pre><code>&lt;a href="https://example.com"
    data-goatcounter-click="ext-example.com"
    data-goatcounter-title="Example event"
-   data-goatcounter-referral="hello"
+   data-goatcounter-referrer="hello"
 &gt;Example&lt;/a&gt;
 </code></pre>
 
@@ -410,7 +410,7 @@ an image on your site:</p>
 <pre><code>&lt;img src="{{.Site.URL}}/count?p=/test-img"&gt;
 </code></pre>
 
-<p>This won’t allow recording the referral or screen size, and may also increase
+<p>This won’t allow recording the referrer or screen size, and may also increase
 the number of bot requests (we do our best to filter this out, but it’s hard to
 get all of them, since many spam scrapers and such disguise themselves as
 regular browsers).</p>

--- a/tpl/_backend_sitecode.markdown
+++ b/tpl/_backend_sitecode.markdown
@@ -26,13 +26,13 @@ link as `ext-example.com`:
 The `name` or `id` attribute will be used if `data-goatcounter-click` is empty,
 in that order.
 
-You can use `data-goatcounter-title` and `data-goatcounter-referral` to set the
-title and/or referral:
+You can use `data-goatcounter-title` and `data-goatcounter-referrer` to set the
+title and/or referrer:
 
     <a href="https://example.com"
        data-goatcounter-click="ext-example.com"
        data-goatcounter-title="Example event"
-       data-goatcounter-referral="hello"
+       data-goatcounter-referrer="hello"
     >Example</a>
 
 The regular `title` attribute or the element’s HTML (capped to 200 characters)
@@ -325,7 +325,7 @@ an image on your site:
 
     <img src="{{.Site.URL}}/count?p=/test-img">
 
-This won’t allow recording the referral or screen size, and may also increase
+This won’t allow recording the referrer or screen size, and may also increase
 the number of bot requests (we do our best to filter this out, but it’s hard to
 get all of them, since many spam scrapers and such disguise themselves as
 regular browsers).


### PR DESCRIPTION
Thank you for this (very) cool project!

The `data-goatcounter-referral` is currently ignored, because the `count` function expect it to be passed as `referrer` (and not as `referral` - as it currently is).

Should `data-goatcounter-referrer` be considered as well for consistency?