### PR TITLE
JS: get the count URL (without hitting - for navigator.sendBeacon)

### DIFF
--- a/CHANGELOG.markdown
+++ b/CHANGELOG.markdown
@@ -43,6 +43,12 @@ Unreleased
   the maximum of all paths in the selected time range, and there's a input to
   scale it lower if desired.
 
+- Add `goatcounter.url()`, `goatcounter.filter()` (#272, #253)
+
+  Adds two new methods to the `count.js` script so it's easier to contract your
+  own implementation. In addition the script will now issue a `console.warn()`
+  if a request isn't being counted for some reason.
+
 
 2020-05-18 v1.2.0
 -----------------

--- a/tpl/_backend_sitecode.gohtml
+++ b/tpl/_backend_sitecode.gohtml
@@ -32,6 +32,10 @@ Use <code>{{.Site.URL}}/count</code> as the endpoint in the WordPress GoatCounte
       <li><a href="#data-parameters" id="markdown-toc-data-parameters">Data parameters</a></li>
       <li><a href="#methods" id="markdown-toc-methods">Methods</a>        <ul>
           <li><a href="#countvars" id="markdown-toc-countvars"><code>count(vars)</code></a></li>
+        </ul>
+      </li>
+      <li><a href="#urlvars" id="markdown-toc-urlvars"><code>url(vars)</code></a></li>
+      <li><a href="#filter" id="markdown-toc-filter"><code>filter()</code></a>        <ul>
           <li><a href="#bindevents" id="markdown-toc-bindevents"><code>bind_events()</code></a></li>
           <li><a href="#getqueryname" id="markdown-toc-getqueryname"><code>get_query(name)</code></a></li>
         </ul>
@@ -45,6 +49,7 @@ Use <code>{{.Site.URL}}/count</code> as the endpoint in the WordPress GoatCounte
       <li><a href="#multiple-domains" id="markdown-toc-multiple-domains">Multiple domains</a></li>
       <li><a href="#ignore-query-parameters-in-path" id="markdown-toc-ignore-query-parameters-in-path">Ignore query parameters in path</a></li>
       <li><a href="#spa" id="markdown-toc-spa">SPA</a></li>
+      <li><a href="#using-navigatorsendbeacon" id="markdown-toc-using-navigatorsendbeacon">Using navigator.sendBeacon</a></li>
       <li><a href="#custom-events" id="markdown-toc-custom-events">Custom events</a></li>
       <li><a href="#consent-notice" id="markdown-toc-consent-notice">Consent notice</a></li>
     </ul>
@@ -190,6 +195,28 @@ it’s available:</p>
 
 <p>The default implementation already handles this, and you only need to worry
 about this if you call <code>count()</code> manually.</p>
+
+<h3 id="urlvars"><code>url(vars)</code> <a href="#urlvars"></a></h3>
+<p>Get URL to send to the server; the <code>vars</code> parameter behaves as <code>count()</code>.</p>
+
+<p>Note that you may want to use <code>filter()</code> to exclude prerender requests and
+various other things.</p>
+
+<h3 id="filter"><code>filter()</code> <a href="#filter"></a></h3>
+<p>Determine if this request should be filtered; this returns a string with the
+reason or <code>false</code>.</p>
+
+<p>This will filter pre-render requests, frames (unless <code>allow_frame</code> is set), and
+local requests (unless <code>allow_local</code> is set).</p>
+
+<p>Example usage:</p>
+
+<pre><code>if (goatcounter.filter()) {
+    if (console &amp;&amp; 'log' in console)
+        console.warn('goatcounter: not counting because of: ' + goatcounter.filter())
+    return
+}
+</code></pre>
 
 <h4 id="bindevents"><code>bind_events()</code> <a href="#bindevents"></a></h4>
 <p>Bind a click event to every element with <code>data-goatcounter-click</code>. Called on
@@ -345,6 +372,24 @@ for navigation then you probably <em>don’t</em> want to do this.</p>
 {{template "code" .}}
 </code></pre>
 
+<h3 id="using-navigatorsendbeacon">Using navigator.sendBeacon <a href="#using-navigatorsendbeacon"></a></h3>
+
+<p>You can use <a href="https://developer.mozilla.org/en-US/docs/Web/API/Navigator/sendBeacon"><code>navigator.sendBeacon()</code></a> with GoatCounter, for example to
+send events when someone closes a page:</p>
+
+<pre><code>&lt;script&gt;
+    if (goatcounter.filter())
+        return
+    navigator.sendBeacon(goatcounter.url({
+        event: true,
+        path: function(p) {
+            return 'unload-' + p
+        },
+    }))
+&lt;/script&gt;
+{{template "code" .}}
+</code></pre>
+
 <h3 id="custom-events">Custom events <a href="#custom-events"></a></h3>
 <p>You can send an event by setting the <code>event</code> parameter to <code>true</code> in <code>count()</code>.
 For example:</p>
@@ -433,8 +478,10 @@ regular browsers).</p>
 <p>Wrap in a <code>&lt;noscript&gt;</code> tag to use this only for people without JavaScript.</p>
 
 <h3 id="tracking-from-backend-middleware">Tracking from backend middleware <a href="#tracking-from-backend-middleware"></a></h3>
-<p>You can call <code>GET {{.Site.URL}}/count</code> from anywhere, such as your app’s
-middleware. It supports the following query parameters:</p>
+<p>You can call <code>GET {{.Site.URL}}/count</code> or <code>POST {{.Site.URL}}/count</code> from
+anywhere, such as your app’s middleware. The GET and POST sendpoints are
+identical, and supportxs the following query parameters (form parameters are
+ignored for POST):</p>
 
 <ul>
   <li><code>p</code> → <code>path</code></li>

--- a/tpl/_backend_sitecode.markdown
+++ b/tpl/_backend_sitecode.markdown
@@ -111,6 +111,27 @@ it’s available:
 The default implementation already handles this, and you only need to worry
 about this if you call `count()` manually.
 
+### `url(vars)`
+Get URL to send to the server; the `vars` parameter behaves as `count()`.
+
+Note that you may want to use `filter()` to exclude prerender requests and
+various other things.
+
+### `filter()`
+Determine if this request should be filtered; this returns a string with the
+reason or `false`.
+
+This will filter pre-render requests, frames (unless `allow_frame` is set), and
+local requests (unless `allow_local` is set).
+
+Example usage:
+
+    if (goatcounter.filter()) {
+        if (console && 'log' in console)
+            console.warn('goatcounter: not counting because of: ' + goatcounter.filter())
+        return
+    }
+
 #### `bind_events()`
 Bind a click event to every element with `data-goatcounter-click`. Called on
 page load unless `no_onload` or `no_events` is set. You may need to call this
@@ -252,6 +273,25 @@ Custom `count()` example for hooking in to an SPA nagivating by `#`:
     </script>
     {{template "code" .}}
 
+### Using navigator.sendBeacon
+
+You can use [`navigator.sendBeacon()`][beacon] with GoatCounter, for example to
+send events when someone closes a page:
+
+    <script>
+        if (goatcounter.filter())
+            return
+        navigator.sendBeacon(goatcounter.url({
+            event: true,
+            path: function(p) {
+                return 'unload-' + p
+            },
+        }))
+    </script>
+    {{template "code" .}}
+
+[beacon]: https://developer.mozilla.org/en-US/docs/Web/API/Navigator/sendBeacon
+
 ### Custom events
 You can send an event by setting the `event` parameter to `true` in `count()`.
 For example:
@@ -339,8 +379,10 @@ regular browsers).
 Wrap in a `<noscript>` tag to use this only for people without JavaScript.
 
 ### Tracking from backend middleware
-You can call `GET {{.Site.URL}}/count` from anywhere, such as your app’s
-middleware. It supports the following query parameters:
+You can call `GET {{.Site.URL}}/count` or `POST {{.Site.URL}}/count` from
+anywhere, such as your app’s middleware. The GET and POST sendpoints are
+identical, and supportxs the following query parameters (form parameters are
+ignored for POST):
 
 - `p` → `path`
 - `e` → `event`


### PR DESCRIPTION
_This PR is mainly to discuss the implementation_

I think this is a good idea!

Maybe instead of exposing three methods, they could be merged into one: `goatcounter.count_url(data)`. To consider edge cases (when the endpoint is not defined, or the host is local) it could return null (or an empty string) in those cases:
```js
	// Get the count url (e.g. "https://code.goatcounter.com/count?p=path&r=search")
	// return null if the count should be ignored (localhost or empty path)
	window.goatcounter.count_url = function(vars) {
		if (!goatcounter.allow_local && location.hostname.match(/(localhost$|^127\.|^10\.|^172\.(1[6-9]|2[0-9]|3[0-1])\.|^192\.168\.)/))
			return

		var script   = document.querySelector('script[data-goatcounter]'),
		    endpoint = (goatcounter.endpoint || window.counter)  // counter is for compat; don't use.
		if (script)
			endpoint = script.dataset.goatcounter
		if (!endpoint) {
			if (console && 'warn' in console)
				console.warn('goatcounter: no endpoint defined')
			return
		}

		var data = get_data(vars || {})
		if (data.p === null)  // null from user callback.
			return
		data.rnd = Math.random().toString(36).substr(2, 5)  // Browsers don't always listen to Cache-Control.
		return endpoint + to_params(data)
	}

	// Count a hit.
	window.goatcounter.count = function(vars) {
		if ('visibilityState' in document && document.visibilityState === 'prerender')
			return
		if (location !== parent.location)  // Frame
			return
		
		var url = goatcounter.count_url(vars)
		if (!url)
			return

		var img = document.createElement('img'),
		    rm  = function() { if (img && img.parentNode) img.parentNode.removeChild(img) }
		img.src = url
		img.style.float = 'right'  // Affect layout less.
		img.setAttribute('alt', '')
		img.setAttribute('aria-hidden', 'true')

		setTimeout(rm, 3000)  // In case the onload isn't triggered.
		img.addEventListener('load', rm, false)
		document.body.appendChild(img)
	}
```

