### PR TITLE
Remove user.Name and site.Name

### DIFF
--- a/admin.go
+++ b/admin.go
@@ -21,7 +21,6 @@ type AdminStat struct {
 	ID         int64     `db:"id"`
 	Parent     *int64    `db:"parent"`
 	Code       string    `db:"code"`
-	Name       string    `db:"name"`
 	LinkDomain string    `db:"link_domain"`
 	User       string    `db:"user"`
 	Email      string    `db:"email"`
@@ -45,18 +44,16 @@ func (a *AdminStats) List(ctx context.Context, order string) error {
 			sites.id,
 			sites.parent,
 			sites.code,
-			sites.name,
 			sites.created_at,
 			(case when substr(sites.stripe, 0, 9) = 'cus_free' then 'free' else sites.plan end) as plan,
 			sites.link_domain,
-			users.name as user,
 			users.email,
 			count(*) - 1 as count
 		from sites
 		left join hits on hits.site=sites.id
 		left join users on users.site=coalesce(sites.parent, sites.id)
 		where hits.created_at >= %s
-		group by sites.id, sites.code, sites.name, sites.created_at, users.name, users.email, plan
+		group by sites.id, sites.code, sites.created_at, users.email, plan
 		having count(*) > 1000
 		order by %s desc`, ival, order))
 	if err != nil {

--- a/cmd/goatcounter/create.go
+++ b/cmd/goatcounter/create.go
@@ -36,8 +36,6 @@ Other flags:
 
   -password      Password to log in; will be asked interactively if omitted.
 
-  -name          Name for the site and user; can be changed later in settings.
-
   -parent        Parent site; either as ID or domain.
 
   -db            Database connection string. Use "sqlite://<dbfile>" for SQLite,
@@ -54,12 +52,11 @@ func create() (int, error) {
 	debug := flagDebug()
 
 	var (
-		domain, email, name, parent, password string
-		createdb                              bool
+		domain, email, parent, password string
+		createdb                        bool
 	)
 	CommandLine.StringVar(&domain, "domain", "", "")
 	CommandLine.StringVar(&email, "email", "", "")
-	CommandLine.StringVar(&name, "name", "serve", "")
 	CommandLine.StringVar(&parent, "parent", "", "")
 	CommandLine.StringVar(&password, "password", "", "")
 	CommandLine.BoolVar(&createdb, "createdb", false, "")
@@ -123,7 +120,6 @@ func create() (int, error) {
 
 	err = zdb.TX(zdb.With(context.Background(), db), func(ctx context.Context, tx zdb.DB) error {
 		s := goatcounter.Site{
-			Name:  name,
 			Code:  "serve-" + zhttp.Secret()[:10],
 			Cname: &domain,
 			Plan:  goatcounter.PlanBusinessPlus,
@@ -138,7 +134,7 @@ func create() (int, error) {
 			return err
 		}
 
-		u := goatcounter.User{Site: s.ID, Name: name, Email: email, Password: []byte(password), EmailVerified: true}
+		u := goatcounter.User{Site: s.ID, Email: email, Password: []byte(password), EmailVerified: true}
 		err = u.Insert(ctx)
 		return err
 	})

--- a/cron/tasks_test.go
+++ b/cron/tasks_test.go
@@ -18,7 +18,7 @@ func TestDataRetention(t *testing.T) {
 	ctx, clean := gctest.DB(t)
 	defer clean()
 
-	site := goatcounter.Site{Code: "bbbb", Name: "bbbb", Plan: goatcounter.PlanPersonal,
+	site := goatcounter.Site{Code: "bbbb", Plan: goatcounter.PlanPersonal,
 		Settings: goatcounter.SiteSettings{DataRetention: 30}}
 	err := site.Insert(ctx)
 	if err != nil {

--- a/db/migrate/pgsql/2020-05-17-1-rm-user-name.sql
+++ b/db/migrate/pgsql/2020-05-17-1-rm-user-name.sql
@@ -1,0 +1,5 @@
+begin;
+	alter table users drop column name;
+	alter table sites drop column name;
+	insert into version values ('2020-05-17-1-rm-user-name');
+commit;

--- a/db/migrate/sqlite/2020-05-17-1-rm-user-name.sql
+++ b/db/migrate/sqlite/2020-05-17-1-rm-user-name.sql
@@ -1,0 +1,64 @@
+begin;
+	insert into version values ('2020-05-17-1-rm-user-name');
+
+	create table users2 (
+		id             integer        primary key autoincrement,
+		site           integer        not null                 check(site > 0),
+
+		password       blob           default null,
+		email          varchar        not null                 check(length(email) > 5 and length(email) <= 255),
+		email_verified int            not null default 0,
+		role           varchar        not null default ''      check(role in ('', 'a')),
+		login_at       timestamp      null                     check(login_at = strftime('%Y-%m-%d %H:%M:%S', login_at)),
+		login_request  varchar        null,
+		login_token    varchar        null,
+		csrf_token     varchar        null,
+		email_token    varchar        null,
+		seen_updates_at timestamp     not null default '1970-01-01 00:00:00' check(seen_updates_at = strftime('%Y-%m-%d %H:%M:%S', seen_updates_at)),
+		reset_at       timestamp      null,
+
+		created_at     timestamp      not null                 check(created_at = strftime('%Y-%m-%d %H:%M:%S', created_at)),
+		updated_at     timestamp                               check(updated_at = strftime('%Y-%m-%d %H:%M:%S', updated_at)),
+
+		foreign key (site) references sites(id) on delete restrict on update restrict
+	);
+	insert into users2 (
+		id, site, password, email, email_verified, role, login_at, login_request, login_token, csrf_token, email_token, seen_updates_at, reset_at, created_at, updated_at
+	) select
+		id, site, password, email, email_verified, role, login_at, login_request, login_token, csrf_token, email_token, seen_updates_at, reset_at, created_at, updated_at
+	from users;
+	drop table users;
+	alter table users2 rename to users;
+	create unique index "users#login_request" on users(login_request);
+	create unique index "users#login_token"   on users(login_token);
+	create        index "users#site"          on users(site);
+	create unique index "users#site#email"    on users(site, lower(email));
+
+	create table sites2 (
+		id             integer        primary key autoincrement,
+		parent         integer        null                     check(parent is null or parent>0),
+
+		code           varchar        not null                 check(length(code) >= 2   and length(code) <= 50),
+		link_domain    varchar        not null default ''      check(link_domain = '' or (length(link_domain) >= 4 and length(link_domain) <= 255)),
+		cname          varchar        null                     check(cname is null or (length(cname) >= 4 and length(cname) <= 255)),
+		plan           varchar        not null                 check(plan in ('personal', 'personalplus', 'business', 'businessplus', 'child', 'custom')),
+		stripe         varchar        null,
+		settings       varchar        not null,
+		received_data  int            not null default 0,
+
+		state          varchar        not null default 'a'     check(state in ('a', 'd')),
+		created_at     timestamp      not null                 check(created_at = strftime('%Y-%m-%d %H:%M:%S', created_at)),
+		updated_at     timestamp                               check(updated_at = strftime('%Y-%m-%d %H:%M:%S', updated_at))
+	);
+	insert into sites2 (
+		id, parent, code, link_domain, cname, plan, stripe, settings, received_data, state, created_at, updated_at
+	) select
+		id, parent, code, link_domain, cname, plan, stripe, settings, received_data, state, created_at, updated_at
+	from sites;
+	drop table sites;
+	alter table sites2 rename to sites;
+
+	create unique index "sites#code" on sites(lower(code));
+
+	insert into version values ('2020-05-17-1-rm-user-name');
+commit;

--- a/db/schema.pgsql
+++ b/db/schema.pgsql
@@ -13,7 +13,6 @@ create table sites (
 	id             serial         primary key,
 	parent         integer        null                     check(parent is null or parent>0),
 
-	name           varchar        not null                 check(length(name) >= 4 and length(name) <= 255),
 	code           varchar        not null                 check(length(code) >= 2 and length(code) <= 50),
 	link_domain    varchar        not null default ''      check(link_domain = '' or (length(link_domain) >= 4 and length(link_domain) <= 255)),
 	cname          varchar        null                     check(cname is null or (length(cname) >= 4 and length(cname) <= 255)),
@@ -33,7 +32,6 @@ create table users (
 	id             serial         primary key,
 	site           integer        not null                 check(site > 0),
 
-	name           varchar        not null,
 	email          varchar        not null                 check(length(email) > 5 and length(email) <= 255),
 	email_verified integer        not null default 0,
 	password       bytea          default null,
@@ -524,6 +522,7 @@ insert into version values
 	('2020-04-20-1-hitsindex'),
 	('2020-04-22-1-campaigns'),
 	('2020-04-27-1-usage-flags'),
-	('2020-05-13-1-unique-path');
+	('2020-05-13-1-unique-path'),
+	('2020-05-17-1-rm-user-name');
 
 -- vim:ft=sql

--- a/db/schema.sql
+++ b/db/schema.sql
@@ -2,7 +2,6 @@ create table sites (
 	id             integer        primary key autoincrement,
 	parent         integer        null                     check(parent is null or parent>0),
 
-	name           varchar        not null                 check(length(name) >= 4 and length(name) <= 255),
 	code           varchar        not null                 check(length(code) >= 2   and length(code) <= 50),
 	link_domain    varchar        not null default ''      check(link_domain = '' or (length(link_domain) >= 4 and length(link_domain) <= 255)),
 	cname          varchar        null                     check(cname is null or (length(cname) >= 4 and length(cname) <= 255)),
@@ -21,7 +20,6 @@ create table users (
 	id             integer        primary key autoincrement,
 	site           integer        not null                 check(site > 0),
 
-	name           varchar        not null,
 	password       blob           default null,
 	email          varchar        not null                 check(length(email) > 5 and length(email) <= 255),
 	email_verified int            not null default 0,
@@ -502,4 +500,5 @@ insert into version values
 	('2020-04-22-1-campaigns'),
 	('2020-04-27-1-usage-flags'),
 	('2020-04-28-1-fix'),
-	('2020-05-13-1-unique-path');
+	('2020-05-13-1-unique-path'),
+	('2020-05-17-1-rm-user-name');

--- a/export.go
+++ b/export.go
@@ -120,7 +120,7 @@ func Export(ctx context.Context, fp *os.File) {
 	user := GetUser(ctx)
 	err = zmail.SendTemplate("GoatCounter export ready",
 		mail.Address{Name: "GoatCounter export", Address: "support@goatcounter.com"},
-		[]mail.Address{{Name: user.Name, Address: user.Email}},
+		[]mail.Address{{Address: user.Email}},
 		"email_export_done.gotxt", struct {
 			Site Site
 			Size string

--- a/gctest/gctest.go
+++ b/gctest/gctest.go
@@ -152,8 +152,8 @@ func DB(t tester) (context.Context, func()) {
 	}
 
 	_, err = db.ExecContext(context.Background(), fmt.Sprintf(
-		`insert into sites (code, name, plan, settings, created_at) values
-		('test', 'example.com', 'personal', '{}', %s);`, now))
+		`insert into sites (code, plan, settings, created_at) values
+		('test', 'personal', '{}', %s);`, now))
 	if err != nil {
 		panic(err)
 	}
@@ -217,9 +217,6 @@ func Site(ctx context.Context, t *testing.T, site goatcounter.Site) (context.Con
 		if len(site.Code) > 50 {
 			site.Code = site.Code[:50]
 		}
-	}
-	if site.Name == "" {
-		site.Name = "name"
 	}
 	if site.Plan == "" {
 		site.Plan = goatcounter.PlanPersonal

--- a/handlers/backend.go
+++ b/handlers/backend.go
@@ -687,7 +687,6 @@ func (h backend) saveSettings(w http.ResponseWriter, r *http.Request) error {
 	v := zvalidate.New()
 
 	args := struct {
-		Name       string                   `json:"name"`
 		Cname      string                   `json:"cname"`
 		LinkDomain string                   `json:"link_domain"`
 		Settings   goatcounter.SiteSettings `json:"settings"`
@@ -720,7 +719,6 @@ func (h backend) saveSettings(w http.ResponseWriter, r *http.Request) error {
 		emailChanged = true
 	}
 
-	user.Name = args.User.Name
 	user.Email = args.User.Email
 	err = user.Update(txctx, emailChanged)
 	if err != nil {
@@ -732,7 +730,6 @@ func (h backend) saveSettings(w http.ResponseWriter, r *http.Request) error {
 	}
 
 	site := goatcounter.MustGetSite(txctx)
-	site.Name = args.Name
 	site.Settings = args.Settings
 	site.LinkDomain = args.LinkDomain
 	if args.Cname != "" && !site.PlanCustomDomain(txctx) {
@@ -872,7 +869,7 @@ func (h backend) removeSubsite(w http.ResponseWriter, r *http.Request) error {
 		return err
 	}
 
-	zhttp.Flash(w, "Site ‘%s ’removed.", s.Name)
+	zhttp.Flash(w, "Site ‘%s ’removed.", s.Code)
 	return zhttp.SeeOther(w, "/settings#tab-additional-sites")
 }
 
@@ -882,7 +879,6 @@ func (h backend) addSubsite(w http.ResponseWriter, r *http.Request) error {
 	}
 
 	args := struct {
-		Name string `json:"name"`
 		Code string `json:"code"`
 	}{}
 	_, err := zhttp.Decode(r, &args)
@@ -893,7 +889,6 @@ func (h backend) addSubsite(w http.ResponseWriter, r *http.Request) error {
 	parent := goatcounter.MustGetSite(r.Context())
 	site := goatcounter.Site{
 		Code:     args.Code,
-		Name:     args.Name,
 		Parent:   &parent.ID,
 		Plan:     goatcounter.PlanChild,
 		Settings: parent.Settings,
@@ -904,7 +899,7 @@ func (h backend) addSubsite(w http.ResponseWriter, r *http.Request) error {
 		return zhttp.SeeOther(w, "/settings#tab-additional-sites")
 	}
 
-	zhttp.Flash(w, "Site ‘%s’ added.", site.Name)
+	zhttp.Flash(w, "Site ‘%s’ added.", site.Code)
 	return zhttp.SeeOther(w, "/settings#tab-additional-sites")
 }
 

--- a/handlers/backend_test.go
+++ b/handlers/backend_test.go
@@ -354,7 +354,6 @@ func TestBackendTpl(t *testing.T) {
 			setup: func(ctx context.Context, t *testing.T) {
 				one := int64(1)
 				ss := goatcounter.Site{
-					Name:   "Subsite",
 					Code:   "subsite",
 					Parent: &one,
 					Plan:   goatcounter.PlanChild,
@@ -368,7 +367,7 @@ func TestBackendTpl(t *testing.T) {
 			path:     "/remove/2",
 			auth:     true,
 			wantCode: 200,
-			wantBody: "Are you sure you want to remove the site Subsite",
+			wantBody: "Are you sure you want to remove the site",
 		},
 	}
 

--- a/handlers/http_test.go
+++ b/handlers/http_test.go
@@ -142,7 +142,7 @@ func login(t *testing.T, rr *httptest.ResponseRecorder, r *http.Request, siteID 
 	t.Helper()
 
 	// Insert user
-	u := goatcounter.User{Site: siteID, Name: "Example", Email: "test@example.com", Password: []byte("coconuts")}
+	u := goatcounter.User{Site: siteID, Email: "test@example.com", Password: []byte("coconuts")}
 	err := u.Insert(r.Context())
 	if err != nil {
 		if guru.Code(err) != 400 {

--- a/handlers/user.go
+++ b/handlers/user.go
@@ -131,7 +131,7 @@ func (h user) requestReset(w http.ResponseWriter, r *http.Request) error {
 		err = zmail.SendTemplate(
 			fmt.Sprintf("Password reset for %s", site.Domain()),
 			mail.Address{Name: "GoatCounter login", Address: cfg.LoginFrom},
-			[]mail.Address{{Name: u.Name, Address: u.Email}},
+			[]mail.Address{{Address: u.Email}},
 			"email_password_reset.gotxt", struct {
 				Site goatcounter.Site
 				User goatcounter.User
@@ -377,7 +377,7 @@ func sendEmailVerify(site *goatcounter.Site, user *goatcounter.User) {
 		defer zlog.Recover()
 		err := zmail.SendTemplate("Verify your email",
 			mail.Address{Name: "GoatCounter", Address: cfg.LoginFrom},
-			[]mail.Address{{Name: user.Name, Address: user.Email}},
+			[]mail.Address{{Address: user.Email}},
 			"email_verify.gotxt", struct {
 				Site goatcounter.Site
 				User goatcounter.User

--- a/handlers/user_test.go
+++ b/handlers/user_test.go
@@ -20,7 +20,7 @@ func TestUserNew(t *testing.T) {
 			name:   "basic",
 			router: newBackend,
 			setup: func(ctx context.Context, t *testing.T) {
-				u := goatcounter.User{Site: 1, Name: "Example", Email: "test@example.com", Password: []byte("coconuts")}
+				u := goatcounter.User{Site: 1, Email: "test@example.com", Password: []byte("coconuts")}
 				err := u.Insert(ctx)
 				if err != nil {
 					t.Fatal(err)
@@ -42,7 +42,7 @@ func TestUserLogin(t *testing.T) {
 		{
 			name: "basic",
 			setup: func(ctx context.Context, t *testing.T) {
-				user := goatcounter.User{Site: 1, Name: "new site", Email: "new@example.com", Password: []byte("coconuts")}
+				user := goatcounter.User{Site: 1, Email: "new@example.com", Password: []byte("coconuts")}
 				err := user.Insert(ctx)
 				if err != nil {
 					panic(err)

--- a/handlers/website.go
+++ b/handlers/website.go
@@ -224,6 +224,13 @@ func (h website) doSignup(w http.ResponseWriter, r *http.Request) error {
 		return err
 	}
 
+	err = user.Login(goatcounter.WithSite(r.Context(), &site))
+	if err != nil {
+		zlog.Errorf("login during account creation: %w", err)
+	} else {
+		zhttp.SetCookie(w, *user.LoginToken, site.Domain())
+	}
+
 	go func() {
 		defer zlog.Recover()
 
@@ -239,13 +246,6 @@ func (h website) doSignup(w http.ResponseWriter, r *http.Request) error {
 			zlog.Errorf("welcome email: %s", err)
 		}
 	}()
-
-	err = user.Login(goatcounter.WithSite(r.Context(), &site))
-	if err != nil {
-		zlog.Errorf("login during account creation: %w", err)
-	} else {
-		zhttp.SetCookie(w, *user.LoginToken, site.Domain())
-	}
 
 	return zhttp.SeeOther(w, fmt.Sprintf("%s/user/new", site.URL()))
 }

--- a/handlers/website_test.go
+++ b/handlers/website_test.go
@@ -57,7 +57,7 @@ func TestWebsiteTpl(t *testing.T) {
 			router:   NewWebsite,
 			path:     "/signup",
 			wantCode: 200,
-			wantBody: `<label for="name">Site name</label>`,
+			wantBody: `<label for="email">Email address</label>`,
 		},
 	}
 
@@ -73,7 +73,7 @@ func TestWebsiteSignup(t *testing.T) {
 			method:       "POST",
 			router:       NewWebsite,
 			path:         "/signup",
-			body:         signupArgs{Name: "Example", Code: "xxx", Email: "m@example.com", TuringTest: "9", Password: "coconuts"},
+			body:         signupArgs{Code: "xxx", Email: "m@example.com", TuringTest: "9", Password: "coconuts"},
 			wantCode:     303,
 			wantFormCode: 303,
 		},
@@ -83,7 +83,7 @@ func TestWebsiteSignup(t *testing.T) {
 			method:       "POST",
 			router:       NewWebsite,
 			path:         "/signup",
-			body:         signupArgs{Name: "Example", Email: "m@example.com", TuringTest: "9", Password: "coconuts"},
+			body:         signupArgs{Email: "m@example.com", TuringTest: "9", Password: "coconuts"},
 			wantCode:     200,
 			wantBody:     "", // TODO: should return JSON
 			wantFormCode: 200,

--- a/site_test.go
+++ b/site_test.go
@@ -19,7 +19,7 @@ func TestSiteInsert(t *testing.T) {
 	ctx, clean := gctest.DB(t)
 	defer clean()
 
-	s := Site{Code: "the-code", Name: "the-code.com", Plan: PlanPersonal}
+	s := Site{Code: "the-code", Plan: PlanPersonal}
 	err := s.Insert(ctx)
 	if err != nil {
 		t.Fatal(err)
@@ -37,24 +37,24 @@ func TestSiteValidate(t *testing.T) {
 		want  map[string][]string
 	}{
 		{
-			Site{Name: "Hello", Code: "hello-0", State: StateActive, Plan: PlanPersonal},
+			Site{Code: "hello-0", State: StateActive, Plan: PlanPersonal},
 			nil,
 			nil,
 		},
 		{
-			Site{Name: "Hello", Code: "h€llo", State: StateActive, Plan: PlanPersonal},
+			Site{Code: "h€llo", State: StateActive, Plan: PlanPersonal},
 			nil,
 			map[string][]string{"code": {"must be a valid hostname: invalid character: '€'"}},
 		},
 		{
-			Site{Name: "Hello", Code: "hel_lo", State: StateActive, Plan: PlanPersonal},
+			Site{Code: "hel_lo", State: StateActive, Plan: PlanPersonal},
 			nil,
 			map[string][]string{"code": {"must be a valid hostname: invalid character: '_'"}},
 		},
 		{
-			Site{Name: "Hello", Code: "hello", State: StateActive, Plan: PlanPersonal},
+			Site{Code: "hello", State: StateActive, Plan: PlanPersonal},
 			func(ctx context.Context) {
-				s := Site{Name: "Hello", Code: "hello", State: StateActive, Plan: PlanPersonal}
+				s := Site{Code: "hello", State: StateActive, Plan: PlanPersonal}
 				err := s.Insert(ctx)
 				if err != nil {
 					panic(err)

--- a/tpl/_backend_top.gohtml
+++ b/tpl/_backend_top.gohtml
@@ -3,7 +3,7 @@
 <head>
 	{{template "_favicon.gohtml" .}}
 	<meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1">
-	<title>{{.Site.Name}} – GoatCounter</title>
+	<title>{{.Site.Code}} – GoatCounter</title>
 	<link rel="stylesheet" href="{{.Static}}/all.min.css?v={{.Version}}">
 	<link rel="stylesheet" href="{{.Static}}/pikaday.css?v={{.Version}}">
 	<link rel="stylesheet" href="{{.Static}}/style_backend.css?v={{.Version}}">

--- a/tpl/backend_admin.gohtml
+++ b/tpl/backend_admin.gohtml
@@ -33,7 +33,7 @@ parent site includes the child sites.</p>
 					{{$s.Code}}
 				{{end}}
 			</td>
-			<td>{{$s.Name}}{{if $s.LinkDomain}} – {{$s.LinkDomain}}{{end}}</td>
+			<td>{{if $s.LinkDomain}} – {{$s.LinkDomain}}{{end}}</td>
 			<td>"{{$s.User}}" &lt;{{$s.Email}}&gt;</td>
 			<td>
 				{{$s.Plan}}

--- a/tpl/backend_remove.gohtml
+++ b/tpl/backend_remove.gohtml
@@ -1,7 +1,7 @@
 {{template "_backend_top.gohtml" .}}
 
-<p>Are you sure you want to remove the site {{.Site.Name}}
-	(<a href="//{{.Site.Code}}.{{.Domain}}">{{.Site.Code}}</a>)?<br>
+<p>Are you sure you want to remove the site
+	<a href="//{{.Site.Code}}.{{.Domain}}">{{.Site.Code}}</a>?<br>
 	This will <strong>remove all associated data</strong>.
 </p>
 <p><a href="//{{.Domain}}/contact" target="_blank">Contact</a> if you want to do

--- a/tpl/backend_settings.gohtml
+++ b/tpl/backend_settings.gohtml
@@ -10,11 +10,6 @@
 
 			<fieldset>
 				<legend>Site settings</legend>
-				<label for="name">Name</label>
-				<input type="text" name="name" id="name" value="{{.Site.Name}}">
-				{{validate "site.name" .Validate}}
-				<span>Your site’s name, e.g. <em>“example.com”</em> or <em>“Example Inc”</em>.</span>
-
 				<label for="link_domain">Domain</label>
 				<input type="text" name="link_domain" id="link_domain" value="{{.Site.LinkDomain}}">
 				{{validate "site.link_domain" .Validate}}
@@ -57,10 +52,6 @@
 
 			<fieldset>
 				<legend>User info and preferences</legend>
-
-				<label for="user.name">Your name</label>
-				<input type="text" name="user.name" id="user.name" value="{{.User.Name}}">
-				{{validate "user.name" .Validate}}
 
 				<label for="user.email">Your email</label>
 				<input type="text" name="user.email" id="user.email" value="{{.User.Email}}">
@@ -180,7 +171,6 @@
 					<tbody>
 						{{range $s := .SubSites}}<tr>
 							<td><a href="//{{$s.Code}}.{{$.Domain}}">{{$s.Code}}</a></td>
-							<td>{{$s.Name}}</td>
 							<td><a href="/remove/{{$s.ID}}">delete</a></td>
 						</tr>{{end}}
 
@@ -189,11 +179,6 @@
 								<input type="text" id="code" name="code" placeholder="Code"><br>
 								<span class="help">You will access your account at https://<em>[my-code]</em>.{{.Domain}}.</span>
 							</td>
-							<td>
-								<input type="text" id="name" name="name" placeholder="Name"><br>
-								<span class="help">Your site’s name, e.g. <em>example.com</em> or <em>Example Inc.</em></span>
-							</td>
-
 							<td><button type="submit">Add new</button></td>
 						</tr>
 				</tbody></table>

--- a/tpl/signup.gohtml
+++ b/tpl/signup.gohtml
@@ -12,18 +12,18 @@
 		<fieldset class="two">
 			<div>
 				<div>
-					<label for="name">Site name</label>
-					<input type="text" name="site_name" id="name" maxlength="255" value="{{.Site.Name}}">
-					{{validate "site.name" .Validate}}
-					<span class="help">Your site’s name, e.g. <em>Example Inc.</em></span>
-				</div>
-
-				<div>
 					<label for="code">Code</label>
 					<input type="text" name="site_code" id="code" maxlength="50" value="{{.Site.Code}}">
 					{{validate "site.code" .Validate}}
 					<span class="help">You will access your account at https://<em>[my-code]</em>.{{.Domain}}.</span>
 				</div>
+				<div>
+					<label for="link_domain">Site domain</label>
+					<input type="text" name="link_domain" id="link_domain" maxlength="255" value="{{.Site.LinkDomain}}">
+					{{validate "site.link_domain" .Validate}}
+					<span class="help">Your site’s domain, optional and only used for display/linking purposes.</em></span>
+				</div>
+
 			</div>
 		</fieldset>
 

--- a/tpl/user.gohtml
+++ b/tpl/user.gohtml
@@ -1,6 +1,6 @@
 {{template "_backend_top.gohtml" .}}
 
-<h1>Sign in at {{.Site.Name}}</h1>
+<h1>Sign in at {{.Site.Code}}</h1>
 {{template "_backend_signin.gohtml" .}}
 
 {{template "_backend_bottom.gohtml" .}}

--- a/tpl/user_reset.gohtml
+++ b/tpl/user_reset.gohtml
@@ -1,6 +1,6 @@
 {{template "_backend_top.gohtml" .}}
 
-<h1>Reset password for {{.User.Email}} at {{.Site.Name}}</h1>
+<h1>Reset password for {{.User.Email}} at {{.Site.Code}}</h1>
 <form method="post" action="/user/reset/{{.Key}}" class="vertical">
 	<label for="password">New password</label>
 	<input type="password" name="password" id="password" required><br>


### PR DESCRIPTION
Not really used anywhere, and it only clutters up the settings and
signup field.

Replace it with the LinkDomain instead on signup.

Also login the user on signup, instead of asking them to login
immediately after signup.