### PR TITLE
Improve performance by adding hit_counts table

### DIFF
--- a/db/migrate/pgsql/2020-05-18-1-domain-count.sql
+++ b/db/migrate/pgsql/2020-05-18-1-domain-count.sql
@@ -1,0 +1,29 @@
+begin;
+	create table hit_counts (
+		site          int        not null check(site>0),
+		path          varchar    not null,
+		title         varchar    not null,
+		event         integer    not null default 0,
+		hour          timestamp  not null,
+		total         int        not null,
+		total_unique  int        not null,
+
+		constraint "hit_counts#site#path#hour#event" unique(site, path, hour, event)
+	);
+	create index "hit_counts#site#hour#event" on hit_counts(site, hour, event);
+
+	insert into hit_counts (site, path, title, event, hour, total, total_unique)
+		select
+				site,
+				max(path),
+				max(title) as title,
+				event,
+				(substring(created_at::varchar, 0, 14) || ':00:00')::timestamp as hour,
+				count(*),
+				sum(first_visit)
+		from hits
+		where bot=0
+		group by site, lower(path), event, hour;
+
+	insert into version values ('2020-05-18-1-domain-count');
+commit;

--- a/db/migrate/sqlite/2020-05-18-1-domain-count.sql
+++ b/db/migrate/sqlite/2020-05-18-1-domain-count.sql
@@ -1,0 +1,29 @@
+begin;
+	create table hit_counts (
+		site          int        not null check(site>0),
+		path          varchar    not null,
+		title         varchar    not null,
+		event         integer    not null default 0,
+		hour          timestamp  not null check(hour = strftime('%Y-%m-%d %H:%M:%S', hour)),
+		total         int        not null,
+		total_unique  int        not null,
+
+		constraint "hit_counts#site#path#hour#event" unique(site, path, hour, event) on conflict replace
+	);
+	create index "hit_counts#site#hour#event" on hit_counts(site, hour, event);
+
+	insert into hit_counts (site, path, title, event, hour, total, total_unique)
+		select
+				site,
+				max(path),
+				max(title) as title,
+				event,
+				(substr(created_at, 0, 14) || ':00:00') as hour,
+				count(*),
+				sum(first_visit)
+		from hits
+		where bot=0
+		group by site, lower(path), event, hour;
+
+	insert into version values ('2020-05-18-1-domain-count');
+commit;

--- a/go.mod
+++ b/go.mod
@@ -19,8 +19,8 @@ require (
 	zgo.at/isbot v0.0.0-20200427181629-1d4940c02e50
 	zgo.at/tz v0.0.0-20200428173314-f4a46a753a7e
 	zgo.at/utils v0.0.0-20200514044306-bf7c1ff8aa0c
-	zgo.at/zdb v0.0.0-20200514044421-e7d35d5f79f1
-	zgo.at/zhttp v0.0.0-20200514040227-c90f02522ddf
+	zgo.at/zdb v0.0.0-20200518092829-2353fffa61c0
+	zgo.at/zhttp v0.0.0-20200518165501-40ecbc2139a8
 	zgo.at/zlog v0.0.0-20200427184116-582329a88e79
 	zgo.at/zpack v1.0.1
 	zgo.at/zstripe v1.0.0

--- a/go.sum
+++ b/go.sum
@@ -73,10 +73,10 @@ zgo.at/tz v0.0.0-20200428173314-f4a46a753a7e h1:IsgWHil+aeBoONa51OzaJqzpy1kFZ55m
 zgo.at/tz v0.0.0-20200428173314-f4a46a753a7e/go.mod h1:A/XeaYjeMGoXptRB3EcR80tgir37tJnzCb6itDaHPxo=
 zgo.at/utils v0.0.0-20200514044306-bf7c1ff8aa0c h1:GWACHp07xLc1JwEISDzITuw1U4x6+r3BdbdYifbHz9E=
 zgo.at/utils v0.0.0-20200514044306-bf7c1ff8aa0c/go.mod h1:+PbZTy2300b/A3oAh7/vJY58X5okaK67qKnAzNKJt3k=
-zgo.at/zdb v0.0.0-20200514044421-e7d35d5f79f1 h1:1UnzlUb3bwJWpbMUeAKzEeEmesNnj03TMK/38Kh+f2o=
-zgo.at/zdb v0.0.0-20200514044421-e7d35d5f79f1/go.mod h1:rHd8UyafKA8OQCesbWO909CyI4iussi0DRxrcjH5j54=
-zgo.at/zhttp v0.0.0-20200514040227-c90f02522ddf h1:8D1BtrOxu2Y0wl7oaLevySQRsVVWRhKBw4rpjEHmM8I=
-zgo.at/zhttp v0.0.0-20200514040227-c90f02522ddf/go.mod h1:lnKdr+Z/u747AVwOkBKweLbFFe0yyvV2JY8NONI4XpQ=
+zgo.at/zdb v0.0.0-20200518092829-2353fffa61c0 h1:yR9QnKvTQJAkoip/d2YI5l0TX7HG/SvjYsMBVQrYEpw=
+zgo.at/zdb v0.0.0-20200518092829-2353fffa61c0/go.mod h1:rHd8UyafKA8OQCesbWO909CyI4iussi0DRxrcjH5j54=
+zgo.at/zhttp v0.0.0-20200518165501-40ecbc2139a8 h1:QJRs7MYjWXo6bX2asLVDffAFxUrBWC8ALADyDhcEVuw=
+zgo.at/zhttp v0.0.0-20200518165501-40ecbc2139a8/go.mod h1:lnKdr+Z/u747AVwOkBKweLbFFe0yyvV2JY8NONI4XpQ=
 zgo.at/zlog v0.0.0-20200404052423-adffcc8acd57 h1:sIuh9IpccNlzMsmAvF7EPT87/Ab2XdUJHizsMxbQgM4=
 zgo.at/zlog v0.0.0-20200404052423-adffcc8acd57/go.mod h1:YkLAQZjLsp1RqWHn8SJokHzXyYU+6FZjM4GNY64IKME=
 zgo.at/zlog v0.0.0-20200427184116-582329a88e79 h1:oHBsncZLO7OuWkJr5Kqyo9asxTYZRZwS1CW2ERdnzOM=

--- a/site.go
+++ b/site.go
@@ -465,6 +465,13 @@ func (s Site) DeleteOlderThan(ctx context.Context, days int) error {
 			return errors.Wrap(err, "Site.DeleteOlderThan: delete sites")
 		}
 
+		_, err = tx.ExecContext(ctx,
+			`delete from hit_counts where site=$1 and hour < `+ival,
+			s.ID)
+		if err != nil {
+			return errors.Wrap(err, "Site.DeleteOlderThan: delete sites")
+		}
+
 		for _, t := range statTables {
 			_, err := tx.ExecContext(ctx,
 				`delete from `+t+` where site=$1 and day < `+ival,

--- a/tpl/backend_admin.gohtml
+++ b/tpl/backend_admin.gohtml
@@ -12,12 +12,13 @@
 <h2>Sites</h2>
 <p>All sites with at least 1,000 hits in the last 30 days; the counts for the
 parent site includes the child sites.</p>
-<table>
+<table style="max-width: none">
 	<tr>
 		<th>ID</th>
-		<th><a href="?order=count"># hits</a></th>
+		<th><a href="?order=last_month">hits/month</a></th>
+		<th><a href="?order=total">total hits</a></th>
 		<th>Code</th>
-		<th>Name</th>
+		<th>Domain</th>
 		<th>User</th>
 		<th>Plan</th>
 		<th><a href="?order=created_at">Created at</a></th>
@@ -25,7 +26,8 @@ parent site includes the child sites.</p>
 	{{range $s := .Stats}}
 		<tr id="{{$s.ID}}" class="plan-{{$s.Plan}}">
 			<td><a href="/admin/{{$s.ID}}">{{$s.ID}}</a></td>
-			<td>{{nformat $s.Count $.Site}}</td>
+			<td>{{nformat $s.LastMonth $.Site}}</td>
+			<td>{{nformat $s.Total $.Site}}</td>
 			<td>
 				{{if $s.Public}}
 					<a href="https://{{$s.Code}}.{{$.Domain}}">{{$s.Code}}</a>
@@ -33,11 +35,23 @@ parent site includes the child sites.</p>
 					{{$s.Code}}
 				{{end}}
 			</td>
-			<td>{{if $s.LinkDomain}} – {{$s.LinkDomain}}{{end}}</td>
-			<td>"{{$s.User}}" &lt;{{$s.Email}}&gt;</td>
+			<td>{{$s.LinkDomain}}</td>
+			<td>{{$s.Email}}</td>
 			<td>
-				{{$s.Plan}}
-				{{if eq $s.Plan "child"}}(<a href="#{{$s.Parent}}">{{$s.Parent}}</a>){{end}}
+				{{if $s.Stripe}}
+					{{$s.Plan}}
+					{{if has_prefix $s.Stripe "cus_github"}}
+					<a href="https://github.com/{{substr $s.Stripe 11 -1}}">GitHub</a>
+					{{else if not (has_prefix $s.Stripe "cus_free_")}}
+						<a href="https://dashboard.stripe.com/customers/{{$s.Stripe}}">Stripe</a>
+					{{end}}
+				{{else}}
+					{{if eq $s.Plan "child"}}
+						child of <a href="#{{$s.Parent}}">{{$s.Parent}}</a>
+					{{else}}
+						free
+					{{end}}
+				{{end}}
 			</td>
 			<td>{{tformat $.Site $s.CreatedAt ""}}</td>
 		</tr>


### PR DESCRIPTION
This adds a new hit_counts table with intermediate counts. This improves
performance by quite a bit.

This is really how hit_stats should have been, instead of aggregating all the
daily stats in one stats row (which is hard to query with TZ support). I might
migrate to this in the future and drop hit_stats, but for now this is fine.

Before on my site when selecting "last year":

	dashboard        40ms  browsers.List
	dashboard        50ms  sizeStat.ListSizes
	dashboard        78ms  locStat.List
	dashboard       111ms  topRefs.List
	HitStats.List  4900ms  select hits
	HitStats.List   134ms  select hits_stats
	HitStats.List    59ms  add hit_stats
	HitStats.List     2ms  fill blanks
	HitStats.List     1ms  tz
	HitStats.List     0ms  add totals
	dashboard      5098ms  get data
	dashboard        19ms  zhttp.Template

After:

	dashboard        27ms  browsers.List
	dashboard        21ms  sizeStat.ListSizes
	dashboard        39ms  locStat.List
	HitStats.List   115ms  select hits
	dashboard        37ms  topRefs.List
	HitStats.List    98ms  select hits_stats
	HitStats.List    62ms  add hit_stats
	HitStats.List     1ms  fill blanks
	HitStats.List     1ms  tz
	HitStats.List     0ms  add totals
	dashboard       280ms  get data
	dashboard        10ms  zhttp.Template

Largest site selecting "last year":

	dashboard        15ms  browsers.List
	dashboard        17ms  sizeStat.ListSizes
	dashboard        35ms  locStat.List
	dashboard        18ms  topRefs.List
	HitStats.List  6861ms  select hits
	HitStats.List    25ms  select hits_stats
	HitStats.List    19ms  add hit_stats
	HitStats.List     2ms  fill blanks
	HitStats.List     1ms  tz
	HitStats.List     1ms  add totals
	dashboard      7182ms  get data
	dashboard        12ms  zhttp.Template

After:

	dashboard         9ms  browsers.List
	HitStats.List    13ms  select hits
	dashboard         9ms  sizeStat.ListSizes
	HitStats.List     8ms  select hits_stats
	dashboard         9ms  locStat.List
	dashboard         5ms  topRefs.List
	HitStats.List    13ms  add hit_stats
	HitStats.List     2ms  fill blanks
	HitStats.List     9ms  tz
	HitStats.List     1ms  add totals
	dashboard        49ms  get data
	dashboard        16ms  zhttp.Template

My site is slower not because it has more hits, but because it has a larger
number of entries because it's older and has more paths with consistent hits:

	(1)=# select count(*), sum(total) from hit_counts where site=1;
	count  │  sum
	───────┼────────
	80845  │ 443918

	(1)=# select count(*), sum(total) from hit_counts where site=133;
	count  │   sum
	───────┼─────────
	4140   │ 2522877