### PR TITLE
Remove per-path chart scaling

### DIFF
--- a/CHANGELOG.markdown
+++ b/CHANGELOG.markdown
@@ -16,9 +16,19 @@ Unreleased
   sense. It's now replaced with `-email-from`, which can be set to just an email
   address.
 
+  **Action required**: if you set the email address with `-auth` you'll have to
+  change it to `-email-from`.
+
 - Improve performance (#265)
 
   Increase performance by quite a bit on large sites and time ranges.
+
+- Remove the per-path scaling (#267)
+
+  Previously GoatCounter would scale the Y-axis different for every path in the
+  dashboard, but this was more confusing than helpful. It's now always scaled to
+  the maximum of all paths in the selected time range, and there's a input to
+  scale it lower if desired.
 
 
 2020-05-18 v1.2.0

--- a/cron/hit_stat.go
+++ b/cron/hit_stat.go
@@ -31,8 +31,6 @@ func updateHitStats(ctx context.Context, hits []goatcounter.Hit) error {
 		type gt struct {
 			count       []int
 			countUnique []int
-			total       int
-			totalUnique int
 			day         string
 			hour        string
 			event       zdb.Bool
@@ -60,12 +58,6 @@ func updateHitStats(ctx context.Context, hits []goatcounter.Hit) error {
 				if err != nil {
 					return err
 				}
-				for _, i := range v.count {
-					v.total += i
-				}
-				for _, i := range v.countUnique {
-					v.totalUnique += i
-				}
 			}
 
 			if h.Title != "" {
@@ -74,9 +66,7 @@ func updateHitStats(ctx context.Context, hits []goatcounter.Hit) error {
 
 			hour, _ := strconv.ParseInt(h.CreatedAt.Format("15"), 10, 8)
 			v.count[hour] += 1
-			v.total += 1
 			if h.FirstVisit {
-				v.totalUnique += 1
 				v.countUnique[hour] += 1
 			}
 			grouped[k] = v

--- a/cron/hit_stat_test.go
+++ b/cron/hit_stat_test.go
@@ -28,8 +28,9 @@ func TestHitStats(t *testing.T) {
 	}...)
 
 	var stats goatcounter.HitStats
-	total, totalUnique, display, displayUnique, more, err := stats.List(ctx, now.Add(-1*time.Hour), now.Add(1*time.Hour), "", nil)
-	_, _ = totalUnique, displayUnique // TODO
+	total, totalUnique, display, displayUnique, max, more, err := stats.List(
+		ctx, now.Add(-1*time.Hour), now.Add(1*time.Hour), "", nil, false)
+	_, _, _ = totalUnique, displayUnique, max // TODO
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -43,13 +44,13 @@ func TestHitStats(t *testing.T) {
 		t.Fatalf("len(stats) is not 2: %d", len(stats))
 	}
 
-	want0 := `{"Count":2,"CountUnique":1,"Max":10,"DailyMax":10,"Path":"/asd","Event":false,"Title":"aSd","RefScheme":null,"Stats":[{"Day":"2019-08-31","Hourly":[0,0,0,0,0,0,0,0,0,0,0,0,0,0,2,0,0,0,0,0,0,0,0,0],"HourlyUnique":[0,0,0,0,0,0,0,0,0,0,0,0,0,0,1,0,0,0,0,0,0,0,0,0],"Daily":2,"DailyUnique":1}]}`
+	want0 := `{"Count":2,"CountUnique":1,"Path":"/asd","Event":false,"Title":"aSd","RefScheme":null,"Stats":[{"Day":"2019-08-31","Hourly":[0,0,0,0,0,0,0,0,0,0,0,0,0,0,2,0,0,0,0,0,0,0,0,0],"HourlyUnique":[0,0,0,0,0,0,0,0,0,0,0,0,0,0,1,0,0,0,0,0,0,0,0,0],"Daily":2,"DailyUnique":1}]}`
 	got0 := string(jsonutil.MustMarshal(stats[0]))
 	if got0 != want0 {
 		t.Errorf("first wrong\ngot:  %s\nwant: %s", got0, want0)
 	}
 
-	want1 := `{"Count":1,"CountUnique":0,"Max":10,"DailyMax":10,"Path":"/zxc","Event":false,"Title":"","RefScheme":null,"Stats":[{"Day":"2019-08-31","Hourly":[0,0,0,0,0,0,0,0,0,0,0,0,0,0,1,0,0,0,0,0,0,0,0,0],"HourlyUnique":[0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0],"Daily":1,"DailyUnique":0}]}`
+	want1 := `{"Count":1,"CountUnique":0,"Path":"/zxc","Event":false,"Title":"","RefScheme":null,"Stats":[{"Day":"2019-08-31","Hourly":[0,0,0,0,0,0,0,0,0,0,0,0,0,0,1,0,0,0,0,0,0,0,0,0],"HourlyUnique":[0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0],"Daily":1,"DailyUnique":0}]}`
 	got1 := string(jsonutil.MustMarshal(stats[1]))
 	if got1 != want1 {
 		t.Errorf("second wrong\ngot:  %s\nwant: %s", got1, want1)

--- a/cron/tasks_test.go
+++ b/cron/tasks_test.go
@@ -52,8 +52,9 @@ func TestDataRetention(t *testing.T) {
 	}
 
 	var stats goatcounter.HitStats
-	total, totalUnique, display, displayUnique, more, err := stats.List(ctx, past.Add(-1*24*time.Hour), now, "", nil)
-	_, _ = totalUnique, displayUnique // TODO
+	total, totalUnique, display, displayUnique, max, more, err := stats.List(
+		ctx, past.Add(-1*24*time.Hour), now, "", nil, false)
+	_, _, _ = totalUnique, displayUnique, max // TODO
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/go.mod
+++ b/go.mod
@@ -18,11 +18,11 @@ require (
 	honnef.co/go/tools v0.0.1-2020.1.4
 	zgo.at/guru v1.1.0
 	zgo.at/isbot v0.0.0-20200427181629-1d4940c02e50
-	zgo.at/tz v0.0.0-20200428173314-f4a46a753a7e
+	zgo.at/tz v0.0.0-20200520034804-aeba38d94d93
 	zgo.at/utils v0.0.0-20200514044306-bf7c1ff8aa0c
 	zgo.at/zdb v0.0.0-20200518092829-2353fffa61c0
 	zgo.at/zhttp v0.0.0-20200520171239-2396be244f0c
-	zgo.at/zlog v0.0.0-20200427184116-582329a88e79
+	zgo.at/zlog v0.0.0-20200519105857-4dc5e4ffe04c
 	zgo.at/zpack v1.0.1
 	zgo.at/zstripe v1.0.0
 	zgo.at/ztest v0.0.0-20200316134318-cfad86d80b41

--- a/go.sum
+++ b/go.sum
@@ -90,6 +90,8 @@ zgo.at/isbot v0.0.0-20200427181629-1d4940c02e50 h1:T6Xej7cvCd9kdrhp9HnZ8cRPf3dQj
 zgo.at/isbot v0.0.0-20200427181629-1d4940c02e50/go.mod h1:/w+LTWbHsV7G5fT41VnwM0kTdk1H/prynfMqaxcBWjA=
 zgo.at/tz v0.0.0-20200428173314-f4a46a753a7e h1:IsgWHil+aeBoONa51OzaJqzpy1kFZ55mUcmuX9AafZY=
 zgo.at/tz v0.0.0-20200428173314-f4a46a753a7e/go.mod h1:A/XeaYjeMGoXptRB3EcR80tgir37tJnzCb6itDaHPxo=
+zgo.at/tz v0.0.0-20200520034804-aeba38d94d93 h1:9jisiomiXkQ2K2yTJQOO5fL+Txg+rKxytHj8G8kRl2M=
+zgo.at/tz v0.0.0-20200520034804-aeba38d94d93/go.mod h1:A/XeaYjeMGoXptRB3EcR80tgir37tJnzCb6itDaHPxo=
 zgo.at/utils v0.0.0-20200514044306-bf7c1ff8aa0c h1:GWACHp07xLc1JwEISDzITuw1U4x6+r3BdbdYifbHz9E=
 zgo.at/utils v0.0.0-20200514044306-bf7c1ff8aa0c/go.mod h1:+PbZTy2300b/A3oAh7/vJY58X5okaK67qKnAzNKJt3k=
 zgo.at/zdb v0.0.0-20200518092829-2353fffa61c0 h1:yR9QnKvTQJAkoip/d2YI5l0TX7HG/SvjYsMBVQrYEpw=
@@ -98,8 +100,8 @@ zgo.at/zhttp v0.0.0-20200520171239-2396be244f0c h1:omWqdUgEe/hvRQYgI+ighQi2DV377
 zgo.at/zhttp v0.0.0-20200520171239-2396be244f0c/go.mod h1:lnKdr+Z/u747AVwOkBKweLbFFe0yyvV2JY8NONI4XpQ=
 zgo.at/zlog v0.0.0-20200404052423-adffcc8acd57 h1:sIuh9IpccNlzMsmAvF7EPT87/Ab2XdUJHizsMxbQgM4=
 zgo.at/zlog v0.0.0-20200404052423-adffcc8acd57/go.mod h1:YkLAQZjLsp1RqWHn8SJokHzXyYU+6FZjM4GNY64IKME=
-zgo.at/zlog v0.0.0-20200427184116-582329a88e79 h1:oHBsncZLO7OuWkJr5Kqyo9asxTYZRZwS1CW2ERdnzOM=
-zgo.at/zlog v0.0.0-20200427184116-582329a88e79/go.mod h1:YkLAQZjLsp1RqWHn8SJokHzXyYU+6FZjM4GNY64IKME=
+zgo.at/zlog v0.0.0-20200519105857-4dc5e4ffe04c h1:PQksY26D9QgCNbOvMmortUzbStTYwfLZHBzHlDDLa6c=
+zgo.at/zlog v0.0.0-20200519105857-4dc5e4ffe04c/go.mod h1:YkLAQZjLsp1RqWHn8SJokHzXyYU+6FZjM4GNY64IKME=
 zgo.at/zpack v1.0.1 h1:muDVwpdzfC/1+U2rsTsv0feI82zxMq0CZuHPZ9RTwJ8=
 zgo.at/zpack v1.0.1/go.mod h1:2laAAHqImmeiTlMAQ2PlMRBVhS6YKPkUoosMfdv7GXY=
 zgo.at/zstripe v1.0.0 h1:rfBrWEUpveYFZKNo4rdc3Fvhb9LEzbMIyL76EXAmXDk=

--- a/handlers/backend_test.go
+++ b/handlers/backend_test.go
@@ -754,8 +754,7 @@ func TestBackendBarChart(t *testing.T) {
 		out = strings.ReplaceAll(out, "</div>\n</div>", "</div></div>")
 		out = strings.TrimSpace(regexp.MustCompile(`[ \t]+<`).ReplaceAllString(out, "<"))
 
-		want = `<span class="top max" title="Y-axis scale">10</span>` + "\n" +
-			`<span class="half"></span>` + "\n" +
+		want = `<span class="half"></span>` + "\n" +
 			strings.TrimSpace(strings.ReplaceAll(want, "\t", ""))
 
 		if d := ztest.Diff(out, want); d != "" {

--- a/hit.go
+++ b/hit.go
@@ -437,10 +437,8 @@ type Stat struct {
 }
 
 type HitStat struct {
-	Count       int `db:"count"`
-	CountUnique int `db:"count_unique"`
-	Max         int
-	DailyMax    int
+	Count       int      `db:"count"`
+	CountUnique int      `db:"count_unique"`
 	Path        string   `db:"path"`
 	Event       zdb.Bool `db:"event"`
 	Title       string   `db:"title"`

--- a/hit_test.go
+++ b/hit_test.go
@@ -45,7 +45,7 @@ func TestHitStatsList(t *testing.T) {
 			},
 			wantReturn: "3 3 false <nil>",
 			wantStats: goatcounter.HitStats{
-				goatcounter.HitStat{Count: 2, Max: 10, Path: "/asd", RefScheme: nil, Stats: []goatcounter.Stat{
+				goatcounter.HitStat{Count: 2, Path: "/asd", RefScheme: nil, Stats: []goatcounter.Stat{
 					{Day: "2019-08-10", Hourly: dayStat(map[int]int{14: 1})},
 					{Day: "2019-08-11", Hourly: dayStat(nil)},
 					{Day: "2019-08-12", Hourly: dayStat(map[int]int{6: 1})},
@@ -55,7 +55,7 @@ func TestHitStatsList(t *testing.T) {
 					{Day: "2019-08-16", Hourly: dayStat(nil)},
 					{Day: "2019-08-17", Hourly: dayStat(nil)},
 				}},
-				goatcounter.HitStat{Count: 1, Max: 10, Path: "/zxc", RefScheme: nil, Stats: []goatcounter.Stat{
+				goatcounter.HitStat{Count: 1, Path: "/zxc", RefScheme: nil, Stats: []goatcounter.Stat{
 					{Day: "2019-08-10", Hourly: dayStat(nil)},
 					{Day: "2019-08-11", Hourly: dayStat(nil)},
 					{Day: "2019-08-12", Hourly: dayStat(nil)},
@@ -75,7 +75,7 @@ func TestHitStatsList(t *testing.T) {
 			inFilter:   "x",
 			wantReturn: "1 1 false <nil>",
 			wantStats: goatcounter.HitStats{
-				goatcounter.HitStat{Count: 1, Max: 10, Path: "/zxc", RefScheme: nil, Stats: []goatcounter.Stat{
+				goatcounter.HitStat{Count: 1, Path: "/zxc", RefScheme: nil, Stats: []goatcounter.Stat{
 					{Day: "2019-08-10", Hourly: dayStat(map[int]int{14: 1})},
 					{Day: "2019-08-11", Hourly: dayStat(nil)},
 					{Day: "2019-08-12", Hourly: dayStat(nil)},
@@ -97,7 +97,7 @@ func TestHitStatsList(t *testing.T) {
 			inFilter:   "a",
 			wantReturn: "4 2 true <nil>",
 			wantStats: goatcounter.HitStats{
-				goatcounter.HitStat{Count: 1, Max: 10, Path: "/aaaa", RefScheme: nil, Stats: []goatcounter.Stat{
+				goatcounter.HitStat{Count: 1, Path: "/aaaa", RefScheme: nil, Stats: []goatcounter.Stat{
 					{Day: "2019-08-10", Hourly: dayStat(map[int]int{14: 1})},
 					{Day: "2019-08-11", Hourly: dayStat(nil)},
 					{Day: "2019-08-12", Hourly: dayStat(nil)},
@@ -107,7 +107,7 @@ func TestHitStatsList(t *testing.T) {
 					{Day: "2019-08-16", Hourly: dayStat(nil)},
 					{Day: "2019-08-17", Hourly: dayStat(nil)},
 				}},
-				goatcounter.HitStat{Count: 1, Max: 10, Path: "/aaa", RefScheme: nil, Stats: []goatcounter.Stat{
+				goatcounter.HitStat{Count: 1, Path: "/aaa", RefScheme: nil, Stats: []goatcounter.Stat{
 					{Day: "2019-08-10", Hourly: dayStat(map[int]int{14: 1})},
 					{Day: "2019-08-11", Hourly: dayStat(nil)},
 					{Day: "2019-08-12", Hourly: dayStat(nil)},
@@ -130,7 +130,7 @@ func TestHitStatsList(t *testing.T) {
 			inExclude:  []string{"/aaaa", "/aaa"},
 			wantReturn: "4 2 false <nil>",
 			wantStats: goatcounter.HitStats{
-				goatcounter.HitStat{Count: 1, Max: 10, Path: "/aa", RefScheme: nil, Stats: []goatcounter.Stat{
+				goatcounter.HitStat{Count: 1, Path: "/aa", RefScheme: nil, Stats: []goatcounter.Stat{
 					{Day: "2019-08-10", Hourly: dayStat(map[int]int{14: 1})},
 					{Day: "2019-08-11", Hourly: dayStat(nil)},
 					{Day: "2019-08-12", Hourly: dayStat(nil)},
@@ -140,7 +140,7 @@ func TestHitStatsList(t *testing.T) {
 					{Day: "2019-08-16", Hourly: dayStat(nil)},
 					{Day: "2019-08-17", Hourly: dayStat(nil)},
 				}},
-				goatcounter.HitStat{Count: 1, Max: 10, Path: "/a", RefScheme: nil, Stats: []goatcounter.Stat{
+				goatcounter.HitStat{Count: 1, Path: "/a", RefScheme: nil, Stats: []goatcounter.Stat{
 					{Day: "2019-08-10", Hourly: dayStat(map[int]int{14: 1})},
 					{Day: "2019-08-11", Hourly: dayStat(nil)},
 					{Day: "2019-08-12", Hourly: dayStat(nil)},
@@ -170,8 +170,9 @@ func TestHitStatsList(t *testing.T) {
 			gctest.StoreHits(ctx, t, tt.in...)
 
 			var stats goatcounter.HitStats
-			total, totalUnique, totalDisplay, uniqueDisplay, more, err := stats.List(ctx, start, end, tt.inFilter, tt.inExclude)
-			_, _ = totalUnique, uniqueDisplay // TODO
+			total, totalUnique, totalDisplay, uniqueDisplay, max, more, err := stats.List(
+				ctx, start, end, tt.inFilter, tt.inExclude, false)
+			_, _, _ = totalUnique, uniqueDisplay, max // TODO
 
 			got := fmt.Sprintf("%d %d %t %v", total, totalDisplay, more, err)
 			if got != tt.wantReturn {

--- a/pack/pack.go
+++ b/pack/pack.go
@@ -14283,7 +14283,7 @@ var Templates = map[string][]byte{
 </body>
 </html>
 `),
-	"tpl/_backend_pages.gohtml": []byte(`{{range $h := .Pages}}
+	"tpl/_backend_pages.gohtml": []byte(`{{range $i, $h := .Pages}}
 	<tr id="{{$h.Path}}"{{if eq $h.Path $.ShowRefs}}class="target"{{end}}>
 		<td>
 			<span title="Visits">{{nformat $h.CountUnique $.Site}}</span><br>
@@ -14303,13 +14303,9 @@ var Templates = map[string][]byte{
 				{{if and $.Site.LinkDomain (not $h.Event)}}<sup><a class="go" target="_blank" rel="noopener" href="https://{{$.Site.LinkDomain}}{{$h.Path}}">go</a></sup>{{end}}
 			</div>
 			<div class="chart chart-bar">
-				{{$max := .Max}}
-				{{if $.Daily}}
-					{{$max = .DailyMax}}
-				{{end}}
-				<span class="top max" title="Y-axis scale">{{nformat $max $.Site}}</span>
+				{{if eq $i 0}}<span class="top max" title="Y-axis scale">{{nformat $.Max $.Site}}</span>{{end}}
 				<span class="half"></span>
-				{{bar_chart $.Context .Stats $max $.Daily}}
+				{{bar_chart $.Context .Stats $.Max $.Daily}}
 			</div>
 			<div class="refs">{{if and $.Refs (eq $.ShowRefs $h.Path)}}
 				{{template "_backend_refs.gohtml" map "Refs" $.Refs "Site" $.Site}}

--- a/pack/pack.go
+++ b/pack/pack.go
@@ -11888,8 +11888,12 @@ http://nicolasgallagher.com/micro-clearfix-hack/
 	// This way you can still hover the entire height.
 	var draw_chart = function() {
 		var redraw = () => {
-			if ($('#scale').val() === $('.count-list-pages').attr('data-scale'))
+			if ($('#scale').val() === $('.count-list-pages').attr('data-scale')) {
+				$('#scale').removeClass('value')
 				return
+			}
+
+			$('#scale').addClass('value')
 			$('.count-list-pages').attr('data-scale', $('#scale').val())
 			$('.chart-bar').each((_, c) => { c.dataset.done = '' })
 			draw_chart()

--- a/pack/pack.go
+++ b/pack/pack.go
@@ -11908,6 +11908,7 @@ http://nicolasgallagher.com/micro-clearfix-hack/
 
 		$('#scale-reset').on('click', (e) => {
 			clearTimeout(t)
+			e.preventDefault()
 			$('#scale').val($('.count-list-pages').attr('data-max'))
 			redraw()
 		})
@@ -12085,8 +12086,12 @@ http://nicolasgallagher.com/micro-clearfix-hack/
 			ud.text(format_int(data.total_unique_display));
 		}
 		else {
-			td.text(format_int(parseInt(td.text().replace(/[^0-9]/, ''), 10) + data.total_display));
-			ud.text(format_int(parseInt(ud.text().replace(/[^0-9]/, ''), 10) + data.total_unique_display));
+			td.each((_, t) => {
+				$(t).text(format_int(parseInt($(t).text().replace(/[^0-9]/, ''), 10) + data.total_display));
+			})
+			ud.each((_, t) => {
+				$(t).text(format_int(parseInt($(t).text().replace(/[^0-9]/, ''), 10) + data.total_unique_display));
+			})
 		}
 
 		draw_chart()
@@ -13201,13 +13206,18 @@ header.h2 { border-bottom: 1px solid #252525; padding-bottom: .2em; margin: 1em 
 .header-pages input#filter-paths,
 .header-pages input#scale,
 .header-pages select#display { padding: .2em; margin-right: 1em; }
-.header-pages input.value { background-color: yellow; }
+.header-pages input.value    { background-color: yellow; }
+.header-pages .totals-small  { display: none; }
 
-@media (max-width: 30rem) {
+@media (max-width: 36rem) {
 	.header-pages input#filter-paths { max-width: 10em; }
+	.header-pages .totals       { display: none; }
+	.header-pages .totals-small { display: block; }
 }
 
 .header-pages input#scale { width: 6em; }
+/* Don't wrap on smaller screens; prefer counts to wrap instead. */
+.header-pages .scale-wrap { white-space: no-wrap; }
 
 h3 + h4 { margin-top: .3em; }
 
@@ -15171,13 +15181,22 @@ Martin
 				Displaying <span class="total-unique-display">{{nformat .TotalUniqueDisplay $.Site}}</span>
 				out of <span class="total-unique">{{nformat .TotalUniqueHits $.Site}}</span>
 				visits;
+				<br class="show-mobile">
 				<span class="views">
 					<span class="total-display">{{nformat .TotalHitsDisplay $.Site}}</span> out of
 					<span class="total-hits">{{nformat .TotalHits $.Site}}</span> pageviews
 				</span>
 			</span>
 
-			<div>
+			<span class="totals totals-small">
+				<span class="total-unique-display">{{nformat .TotalUniqueDisplay $.Site}}</span>/<span class="total-unique">{{nformat .TotalUniqueHits $.Site}}</span> visits
+				<br class="show-mobile">
+				<span class="views">
+					<span class="total-display">{{nformat .TotalHitsDisplay $.Site}}</span>/<span class="total-hits">{{nformat .TotalHits $.Site}}</span> views
+				</span>
+			</span>
+
+			<div class="scale-wrap">
 				<a href="#" id="scale-reset" title="Reset Y-axis scale to the default value">reset</a>
 				<input type="number"autocomplete="off" name="scale" id="scale" value="{{.Max}}"
 					placeholder="Scale" title="Set the Y-axis scale">

--- a/public/script_backend.js
+++ b/public/script_backend.js
@@ -56,8 +56,12 @@
 	// This way you can still hover the entire height.
 	var draw_chart = function() {
 		var redraw = () => {
-			if ($('#scale').val() === $('.count-list-pages').attr('data-scale'))
+			if ($('#scale').val() === $('.count-list-pages').attr('data-scale')) {
+				$('#scale').removeClass('value')
 				return
+			}
+
+			$('#scale').addClass('value')
 			$('.count-list-pages').attr('data-scale', $('#scale').val())
 			$('.chart-bar').each((_, c) => { c.dataset.done = '' })
 			draw_chart()

--- a/public/script_backend.js
+++ b/public/script_backend.js
@@ -55,6 +55,32 @@
 	//
 	// This way you can still hover the entire height.
 	var draw_chart = function() {
+		var redraw = () => {
+			if ($('#scale').val() === $('.count-list-pages').attr('data-scale'))
+				return
+			$('.count-list-pages').attr('data-scale', $('#scale').val())
+			$('.chart-bar').each((_, c) => { c.dataset.done = '' })
+			draw_chart()
+		}
+
+		var t;
+		$('#scale')
+			.on('keydown', (e) => {
+				if (e.keyCode === 13)
+					e.preventDefault()
+			})
+			.on('input', (e) => {
+				clearTimeout(t)
+				t = setTimeout(redraw, 300)
+			})
+
+		$('#scale-reset').on('click', (e) => {
+			clearTimeout(t)
+			$('#scale').val($('.count-list-pages').attr('data-max'))
+			redraw()
+		})
+
+		var scale = parseInt($('#scale').val(), 10) / parseInt($('.count-list-pages').attr('data-max'), 10)
 		$('.chart-bar').each(function(i, chart) {
 			if (chart.dataset.done === 't')
 				return
@@ -63,14 +89,25 @@
 			chart.style.display = 'none'
 
 			$(chart).find('>div').each(function(i, bar) {
-				var h = bar.style.height
-				bar.style.height = '100%'
+				if (bar.dataset.h !== undefined)
+					var h = bar.dataset.h
+				else {
+					var h = bar.style.height
+					bar.dataset.h = h
+					bar.style.height = '100%'
+				}
+
 				if (bar.className === 'f')
 					return
 				else if (h === '')
 					bar.style.background = 'transparent'
 				else {
 					var hu = bar.dataset.u
+					if (scale && scale !== 1) {
+						h  = (parseInt(h, 10)  / scale) + '%'
+						hu = (parseInt(hu, 10) / scale) + '%'
+					}
+
 					bar.style.background = `
 						linear-gradient(to top,
 						#9a15a4 0%,
@@ -156,12 +193,12 @@
 					},
 				});
 			}, 300);
-		});
+		})
 
 		// Don't submit form on enter.
 		$('#filter-paths').on('keydown', function(e) {
 			if (e.keyCode === 13)
-				e.preventDefault();
+				e.preventDefault()
 		})
 	};
 
@@ -577,7 +614,7 @@
 		// Translucent hover effect; need a new div because the height isn't
 		// 100%
 		var add_cursor = function(t) {
-			if (t.closest('.chart-bar').length === 0 || t.is('#cursor') || t.is('.max'))
+			if (t.closest('.chart-bar').length === 0 || t.is('#cursor'))
 				return
 
 			$('#cursor').remove()

--- a/public/script_backend.js
+++ b/public/script_backend.js
@@ -76,6 +76,7 @@
 
 		$('#scale-reset').on('click', (e) => {
 			clearTimeout(t)
+			e.preventDefault()
 			$('#scale').val($('.count-list-pages').attr('data-max'))
 			redraw()
 		})
@@ -253,8 +254,12 @@
 			ud.text(format_int(data.total_unique_display));
 		}
 		else {
-			td.text(format_int(parseInt(td.text().replace(/[^0-9]/, ''), 10) + data.total_display));
-			ud.text(format_int(parseInt(ud.text().replace(/[^0-9]/, ''), 10) + data.total_unique_display));
+			td.each((_, t) => {
+				$(t).text(format_int(parseInt($(t).text().replace(/[^0-9]/, ''), 10) + data.total_display));
+			})
+			ud.each((_, t) => {
+				$(t).text(format_int(parseInt($(t).text().replace(/[^0-9]/, ''), 10) + data.total_unique_display));
+			})
 		}
 
 		draw_chart()

--- a/public/style_backend.css
+++ b/public/style_backend.css
@@ -391,13 +391,18 @@ header.h2 { border-bottom: 1px solid #252525; padding-bottom: .2em; margin: 1em 
 .header-pages input#filter-paths,
 .header-pages input#scale,
 .header-pages select#display { padding: .2em; margin-right: 1em; }
-.header-pages input.value { background-color: yellow; }
+.header-pages input.value    { background-color: yellow; }
+.header-pages .totals-small  { display: none; }
 
-@media (max-width: 30rem) {
+@media (max-width: 36rem) {
 	.header-pages input#filter-paths { max-width: 10em; }
+	.header-pages .totals       { display: none; }
+	.header-pages .totals-small { display: block; }
 }
 
 .header-pages input#scale { width: 6em; }
+/* Don't wrap on smaller screens; prefer counts to wrap instead. */
+.header-pages .scale-wrap { white-space: no-wrap; }
 
 h3 + h4 { margin-top: .3em; }
 

--- a/public/style_backend.css
+++ b/public/style_backend.css
@@ -181,8 +181,7 @@ form .err  { color: red; display: block; }
 	width: 100%;
 	position: relative;
 }
-/* Add a bit extra space between the charts, mostly so it's clearer where the
- * .max belongs to when you're scrolled down. */
+/* Add a bit extra space between the charts */
 @media (min-width: 55rem) {
 	.chart { margin-bottom: 1em; }
 }
@@ -194,7 +193,6 @@ form .err  { color: red; display: block; }
 	top: -1.2em;
 }
 .go { word-break: normal; }
-.chart > .max { right: .2em; }
 
 /* Bar char */
 .chart-bar {
@@ -391,12 +389,15 @@ header.h2 { border-bottom: 1px solid #252525; padding-bottom: .2em; margin: 1em 
 .header-pages span    { margin-left: 0; }
 .header-pages .totals { flex-grow: 1; }
 .header-pages input#filter-paths,
+.header-pages input#scale,
 .header-pages select#display { padding: .2em; margin-right: 1em; }
 .header-pages input.value { background-color: yellow; }
 
 @media (max-width: 30rem) {
 	.header-pages input#filter-paths { max-width: 10em; }
 }
+
+.header-pages input#scale { width: 6em; }
 
 h3 + h4 { margin-top: .3em; }
 

--- a/tpl/_backend_pages.gohtml
+++ b/tpl/_backend_pages.gohtml
@@ -1,4 +1,4 @@
-{{range $h := .Pages}}
+{{range $i, $h := .Pages}}
 	<tr id="{{$h.Path}}"{{if eq $h.Path $.ShowRefs}}class="target"{{end}}>
 		<td>
 			<span title="Visits">{{nformat $h.CountUnique $.Site}}</span><br>
@@ -18,13 +18,9 @@
 				{{if and $.Site.LinkDomain (not $h.Event)}}<sup><a class="go" target="_blank" rel="noopener" href="https://{{$.Site.LinkDomain}}{{$h.Path}}">go</a></sup>{{end}}
 			</div>
 			<div class="chart chart-bar">
-				{{$max := .Max}}
-				{{if $.Daily}}
-					{{$max = .DailyMax}}
-				{{end}}
-				<span class="top max" title="Y-axis scale">{{nformat $max $.Site}}</span>
+				{{if eq $i 0}}<span class="top max" title="Y-axis scale">{{nformat $.Max $.Site}}</span>{{end}}
 				<span class="half"></span>
-				{{bar_chart $.Context .Stats $max $.Daily}}
+				{{bar_chart $.Context .Stats $.Max $.Daily}}
 			</div>
 			<div class="refs">{{if and $.Refs (eq $.ShowRefs $h.Path)}}
 				{{template "_backend_refs.gohtml" map "Refs" $.Refs "Site" $.Site}}

--- a/tpl/_backend_pages.gohtml
+++ b/tpl/_backend_pages.gohtml
@@ -18,7 +18,6 @@
 				{{if and $.Site.LinkDomain (not $h.Event)}}<sup><a class="go" target="_blank" rel="noopener" href="https://{{$.Site.LinkDomain}}{{$h.Path}}">go</a></sup>{{end}}
 			</div>
 			<div class="chart chart-bar">
-				{{if eq $i 0}}<span class="top max" title="Y-axis scale">{{nformat $.Max $.Site}}</span>{{end}}
 				<span class="half"></span>
 				{{bar_chart $.Context .Stats $.Max $.Daily}}
 			</div>

--- a/tpl/backend.gohtml
+++ b/tpl/backend.gohtml
@@ -124,14 +124,21 @@
 					<span class="total-hits">{{nformat .TotalHits $.Site}}</span> pageviews
 				</span>
 			</span>
+
+			<div>
+				<a href="#" id="scale-reset" title="Reset Y-axis scale to the default value">reset</a>
+				<input type="number"autocomplete="off" name="scale" id="scale" value="{{.Max}}"
+					placeholder="Scale" title="Set the Y-axis scale">
+			</div>
+
 			<div class="filter-wrap">
-				<input autocomplete="off" name="filter" value="{{.Filter}}" id="filter-paths" placeholder="Filter paths"
-					{{if .Filter}}class="value"{{end}}
-					title="Filter the list of paths; matched case-insensitive on path and title">
+				<input type="text" autocomplete="off" name="filter" value="{{.Filter}}" id="filter-paths"
+					placeholder="Filter paths" title="Filter the list of paths; matched case-insensitive on path and title"
+					{{if .Filter}}class="value"{{end}}>
 			</div>
 		</header>
 
-		<table class="count-list count-list-pages">
+		<table class="count-list count-list-pages" data-max="{{.Max}}" data-scale="{{.Max}}">
 			<tbody>{{template "_backend_pages.gohtml" .}}</tbody>
 		</table>
 

--- a/tpl/backend.gohtml
+++ b/tpl/backend.gohtml
@@ -119,13 +119,22 @@
 				Displaying <span class="total-unique-display">{{nformat .TotalUniqueDisplay $.Site}}</span>
 				out of <span class="total-unique">{{nformat .TotalUniqueHits $.Site}}</span>
 				visits;
+				<br class="show-mobile">
 				<span class="views">
 					<span class="total-display">{{nformat .TotalHitsDisplay $.Site}}</span> out of
 					<span class="total-hits">{{nformat .TotalHits $.Site}}</span> pageviews
 				</span>
 			</span>
 
-			<div>
+			<span class="totals totals-small">
+				<span class="total-unique-display">{{nformat .TotalUniqueDisplay $.Site}}</span>/<span class="total-unique">{{nformat .TotalUniqueHits $.Site}}</span> visits
+				<br class="show-mobile">
+				<span class="views">
+					<span class="total-display">{{nformat .TotalHitsDisplay $.Site}}</span>/<span class="total-hits">{{nformat .TotalHits $.Site}}</span> views
+				</span>
+			</span>
+
+			<div class="scale-wrap">
 				<a href="#" id="scale-reset" title="Reset Y-axis scale to the default value">reset</a>
 				<input type="number"autocomplete="off" name="scale" id="scale" value="{{.Max}}"
 					placeholder="Scale" title="Set the Y-axis scale">


### PR DESCRIPTION
I looked over some public sites, and it actually looks pretty okay
without the scaling.

Especially with #260 the scaling looks really weird would look just
plain weird.

Added a frontend feature to scale everything to something more narrow if
desired.

Edge case: one site has 150 pageviews in a very short span (max=96), and
many paths with more pageviews. This one narrow spike isn't until the
third page.

Fixes #249
