### PR TITLE
Disallow events starting with a /

### DIFF
--- a/cron/browser_stat.go
+++ b/cron/browser_stat.go
@@ -24,12 +24,11 @@ import (
 //     1 | 2019-12-17 | Opera   | 9       |     1
 func updateBrowserStats(ctx context.Context, hits []goatcounter.Hit) error {
 	return zdb.TX(ctx, func(ctx context.Context, tx zdb.DB) error {
-		// Group by day + browser + event.
+		// Group by day + browser.
 		type gt struct {
 			count       int
 			countUnique int
 			day         string
-			event       zdb.Bool
 			browser     string
 			version     string
 		}
@@ -45,16 +44,15 @@ func updateBrowserStats(ctx context.Context, hits []goatcounter.Hit) error {
 			}
 
 			day := h.CreatedAt.Format("2006-01-02")
-			k := fmt.Sprintf("%s%s%s%t", day, browser, version, h.Event)
+			k := fmt.Sprintf("%s%s%s", day, browser, version)
 			v := grouped[k]
 			if v.count == 0 {
 				v.day = day
 				v.browser = browser
 				v.version = version
-				v.event = h.Event
 				var err error
 				v.count, v.countUnique, err = existingBrowserStats(ctx, tx,
-					h.Site, day, v.browser, v.version, v.event)
+					h.Site, day, v.browser, v.version)
 				if err != nil {
 					return err
 				}
@@ -69,9 +67,9 @@ func updateBrowserStats(ctx context.Context, hits []goatcounter.Hit) error {
 
 		siteID := goatcounter.MustGetSite(ctx).ID
 		ins := bulk.NewInsert(ctx, "browser_stats", []string{"site", "day",
-			"browser", "version", "count", "count_unique", "event"})
+			"browser", "version", "count", "count_unique"})
 		for _, v := range grouped {
-			ins.Values(siteID, v.day, v.browser, v.version, v.count, v.countUnique, v.event)
+			ins.Values(siteID, v.day, v.browser, v.version, v.count, v.countUnique)
 		}
 		return ins.Finish()
 	})
@@ -79,16 +77,15 @@ func updateBrowserStats(ctx context.Context, hits []goatcounter.Hit) error {
 
 func existingBrowserStats(
 	txctx context.Context, tx zdb.DB, siteID int64,
-	day, browser, version string, event zdb.Bool,
+	day, browser, version string,
 ) (int, int, error) {
 
 	var c []struct {
-		Count       int      `db:"count"`
-		CountUnique int      `db:"count_unique"`
-		Event       zdb.Bool `db:"event"`
+		Count       int `db:"count"`
+		CountUnique int `db:"count_unique"`
 	}
 	err := tx.SelectContext(txctx, &c, `/* existingBrowserStats */
-		select count, count_unique, event from browser_stats
+		select count, count_unique from browser_stats
 		where site=$1 and day=$2 and browser=$3 and version=$4 limit 1`,
 		siteID, day, browser, version)
 	if err != nil {
@@ -99,8 +96,8 @@ func existingBrowserStats(
 	}
 
 	_, err = tx.ExecContext(txctx, `delete from browser_stats where
-		site=$1 and day=$2 and browser=$3 and version=$4 and event=$5`,
-		siteID, day, browser, version, event)
+		site=$1 and day=$2 and browser=$3 and version=$4`,
+		siteID, day, browser, version)
 	return c[0].Count, c[0].CountUnique, errors.Wrap(err, "delete")
 }
 

--- a/cron/location_stat.go
+++ b/cron/location_stat.go
@@ -22,12 +22,11 @@ import (
 //     1 | 2019-11-30 | MX       |     4
 func updateLocationStats(ctx context.Context, hits []goatcounter.Hit) error {
 	return zdb.TX(ctx, func(ctx context.Context, tx zdb.DB) error {
-		// Group by day + location + event.
+		// Group by day + location.
 		type gt struct {
 			count       int
 			countUnique int
 			day         string
-			event       zdb.Bool
 			location    string
 		}
 		grouped := map[string]gt{}
@@ -37,15 +36,14 @@ func updateLocationStats(ctx context.Context, hits []goatcounter.Hit) error {
 			}
 
 			day := h.CreatedAt.Format("2006-01-02")
-			k := fmt.Sprintf("%s%s%t", day, h.Location, h.Event)
+			k := fmt.Sprintf("%s%s", day, h.Location)
 			v := grouped[k]
 			if v.count == 0 {
 				v.day = day
 				v.location = h.Location
-				v.event = h.Event
 				var err error
 				v.count, v.countUnique, err = existingLocationStats(ctx, tx,
-					h.Site, day, v.location, v.event)
+					h.Site, day, v.location)
 				if err != nil {
 					return err
 				}
@@ -60,9 +58,9 @@ func updateLocationStats(ctx context.Context, hits []goatcounter.Hit) error {
 
 		siteID := goatcounter.MustGetSite(ctx).ID
 		ins := bulk.NewInsert(ctx, "location_stats", []string{"site", "day",
-			"location", "count", "count_unique", "event"})
+			"location", "count", "count_unique"})
 		for _, v := range grouped {
-			ins.Values(siteID, v.day, v.location, v.count, v.countUnique, v.event)
+			ins.Values(siteID, v.day, v.location, v.count, v.countUnique)
 		}
 		return ins.Finish()
 	})
@@ -70,16 +68,15 @@ func updateLocationStats(ctx context.Context, hits []goatcounter.Hit) error {
 
 func existingLocationStats(
 	txctx context.Context, tx zdb.DB, siteID int64,
-	day, location string, event zdb.Bool,
+	day, location string,
 ) (int, int, error) {
 
 	var c []struct {
-		Count       int      `db:"count"`
-		CountUnique int      `db:"count_unique"`
-		Event       zdb.Bool `db:"event"`
+		Count       int `db:"count"`
+		CountUnique int `db:"count_unique"`
 	}
 	err := tx.SelectContext(txctx, &c, `/* existingLocationStats */
-		select count, count_unique, event from location_stats
+		select count, count_unique from location_stats
 		where site=$1 and day=$2 and location=$3 limit 1`,
 		siteID, day, location)
 	if err != nil {
@@ -90,7 +87,7 @@ func existingLocationStats(
 	}
 
 	_, err = tx.ExecContext(txctx, `delete from location_stats where
-		site=$1 and day=$2 and location=$3 and event=$4`,
-		siteID, day, location, event)
+		site=$1 and day=$2 and location=$3`,
+		siteID, day, location)
 	return c[0].Count, c[0].CountUnique, errors.Wrap(err, "delete")
 }

--- a/db/migrate/pgsql/2020-05-23-1-event.sql
+++ b/db/migrate/pgsql/2020-05-23-1-event.sql
@@ -1,0 +1,19 @@
+begin;
+	update hits       set path=substr(path, 2) where event=1 and path like '/%';
+	update hit_counts set path=substr(path, 2) where event=1 and path like '/%';
+	update hit_stats  set path=substr(path, 2) where event=1 and path like '/%';
+
+	drop index "hit_counts#site#hour#event";
+	create index "hit_counts#site#hour" on hit_counts(site, hour);
+	alter table hit_counts drop constraint "hit_counts#site#path#hour#event";
+	alter table hit_counts add constraint "hit_counts#site#path#hour" unique(site, path, hour);
+
+	alter table hit_stats       drop column event;
+	alter table browser_stats   drop column event;
+	alter table system_stats    drop column event;
+	alter table location_stats  drop column event;
+	alter table ref_stats       drop column event;
+	alter table size_stats      drop column event;
+
+	insert into version values ('2020-05-23-1-event');
+commit;

--- a/db/migrate/sqlite/2020-05-23-1-event.sql
+++ b/db/migrate/sqlite/2020-05-23-1-event.sql
@@ -1,0 +1,147 @@
+begin;
+	update hits       set path=substr(path, 2) where event=1 and path like '/%';
+	update hit_counts set path=substr(path, 2) where event=1 and path like '/%';
+	update hit_stats  set path=substr(path, 2) where event=1 and path like '/%';
+
+	-- drop index "hit_counts#site#hour#event";
+	-- create index "hit_counts#site#hour" on hit_counts(site, hour);
+	-- alter table hit_counts drop constraint "hit_counts#site#path#hour#event";
+	-- alter table hit_counts add constraint "hit_counts#site#path#hour" unique(site, path, hour);
+	create table hit_counts2 (
+		site          int        not null check(site>0),
+		path          varchar    not null,
+		title         varchar    not null,
+		event         integer    not null default 0,
+		hour          timestamp  not null check(hour = strftime('%Y-%m-%d %H:%M:%S', hour)),
+		total         int        not null,
+		total_unique  int        not null,
+
+		constraint "hit_counts2#site#path#hour" unique(site, path, hour) on conflict replace
+	);
+	insert into hit_counts2 select
+		site, path, title, event, hour, total, total_unique
+	from hit_counts;
+	drop table hit_counts;
+	alter table hit_counts2 rename to hit_counts;
+	create index "hit_counts#site#hour" on hit_counts(site, hour);
+
+	-- alter table hit_stats       drop column event;
+	create table hit_stats2 (
+		site           integer        not null                 check(site > 0),
+
+		day            date           not null                 check(day = strftime('%Y-%m-%d', day)),
+		path           varchar        not null,
+		title          varchar        not null default '',
+		stats          varchar        not null,
+		stats_unique   varchar        not null,
+
+		foreign key (site) references sites(id) on delete restrict on update restrict
+	);
+	insert into hit_stats2 select
+		site, day, path, title, stats, stats_unique
+	from hit_stats;
+	drop table hit_stats;
+	alter table hit_stats2 rename to hit_stats;
+	create index "hit_stats#site#day" on hit_stats(site, day);
+
+	-- alter table browser_stats   drop column event;
+	create table browser_stats2 (
+		site           integer        not null                 check(site > 0),
+
+		day            date           not null                 check(day = strftime('%Y-%m-%d', day)),
+		browser        varchar        not null,
+		version        varchar        not null,
+		count          int            not null,
+		count_unique   int            not null,
+
+		foreign key (site) references sites(id) on delete restrict on update restrict
+	);
+	insert into browser_stats2 select
+		site, day, browser, version, count, count_unique
+	from browser_stats;
+	drop table browser_stats;
+	alter table browser_stats2 rename to browser_stats;
+	create index "browser_stats#site#day"         on browser_stats(site, day);
+	create index "browser_stats#site#day#browser" on browser_stats(site, day, browser);
+
+	-- alter table system_stats    drop column event;
+	create table system_stats2 (
+		site           integer        not null                 check(site > 0),
+
+		day            date           not null                 check(day = strftime('%Y-%m-%d', day)),
+		system         varchar        not null,
+		version        varchar        not null,
+		count          int            not null,
+		count_unique   int            not null,
+
+		foreign key (site) references sites(id) on delete restrict on update restrict
+	);
+	insert into system_stats2 select
+		site, day, system, version, count, count_unique
+	from system_stats;
+	drop table system_stats;
+	alter table system_stats2 rename to system_stats;
+	create index "system_stats#site#day"        on system_stats(site, day);
+	create index "system_stats#site#day#system" on system_stats(site, day, system);
+
+	-- alter table location_stats  drop column event;
+	create table location_stats2 (
+		site           integer        not null                 check(site > 0),
+
+		day            date           not null                 check(day = strftime('%Y-%m-%d', day)),
+		location       varchar        not null,
+		count          int            not null,
+		count_unique   int            not null,
+
+		foreign key (site) references sites(id) on delete restrict on update restrict
+	);
+	insert into location_stats2 select
+		site, day, location, count, count_unique
+	from location_stats;
+	drop table location_stats;
+	alter table location_stats2 rename to location_stats;
+	create index "location_stats#site#day"          on location_stats(site, day);
+	create index "location_stats#site#day#location" on location_stats(site, day, location);
+
+	-- alter table ref_stats       drop column event;
+	create table ref_stats2 (
+		site           integer        not null                 check(site > 0),
+
+		day            date           not null                 check(day = strftime('%Y-%m-%d', day)),
+		ref            varchar        not null,
+		count          int            not null,
+		count_unique   int            not null,
+
+		foreign key (site) references sites(id) on delete restrict on update restrict
+	);
+	insert into ref_stats2 select
+		site, day, ref, count, count_unique
+	from ref_stats;
+	drop table ref_stats;
+	alter table ref_stats2 rename to ref_stats;
+	create index "ref_stats#site#day" on ref_stats(site, day);
+
+	-- alter table size_stats      drop column event;
+	create table size_stats2 (
+		site           integer        not null                 check(site > 0),
+
+		day            date           not null                 check(day = strftime('%Y-%m-%d', day)),
+		width          int            not null,
+		count          int            not null,
+		count_unique   int            not null,
+
+		foreign key (site) references sites(id) on delete restrict on update restrict
+	);
+	insert into size_stats2 select
+		site, day, width, count, count_unique
+	from size_stats;
+	drop table size_stats;
+	alter table size_stats2 rename to size_stats;
+	create index "size_stats#site#day"       on size_stats(site, day);
+	create index "size_stats#site#day#width" on size_stats(site, day, width);
+
+
+	update hits set path=substr(path, 1) where event=1 and path like '/%';
+	insert into version values ('2020-05-23-1-event');
+commit;
+

--- a/hit.go
+++ b/hit.go
@@ -203,6 +203,7 @@ func cleanRefURL(ref string, refURL *url.URL) (string, *string, bool, bool) {
 
 func (h *Hit) cleanPath(ctx context.Context) {
 	if h.Event {
+		h.Path = strings.TrimLeft(h.Path, "/")
 		return
 	}
 
@@ -374,7 +375,7 @@ func (h *Hit) Validate(ctx context.Context) error {
 	v.UTF8("ref", h.Ref)
 	v.UTF8("browser", h.Browser)
 
-	v.Len("path", h.Path, 0, 2048)
+	v.Len("path", h.Path, 1, 2048)
 	v.Len("title", h.Title, 0, 1024)
 	v.Len("ref", h.Ref, 0, 2048)
 	v.Len("browser", h.Browser, 0, 512)

--- a/hit_list.go
+++ b/hit_list.go
@@ -120,14 +120,13 @@ func (h *HitStats) List(
 	var st []struct {
 		Path        string    `db:"path"`
 		Title       string    `db:"title"`
-		Event       zdb.Bool  `db:"event"`
 		Day         time.Time `db:"day"`
 		Stats       []byte    `db:"stats"`
 		StatsUnique []byte    `db:"stats_unique"`
 	}
 	{
 		query := `/* HitStats.List: get stats */
-			select path, event, title, day, stats, stats_unique
+			select path, title, day, stats, stats_unique
 			from hit_stats
 			where
 				site=$1 and
@@ -152,12 +151,11 @@ func (h *HitStats) List(
 	{
 		for i := range hh {
 			for _, s := range st {
-				if s.Path == hh[i].Path && s.Event == hh[i].Event {
+				if s.Path == hh[i].Path {
 					var x, y []int
 					jsonutil.MustUnmarshal(s.Stats, &x)
 					jsonutil.MustUnmarshal(s.StatsUnique, &y)
 					hh[i].Title = s.Title
-					hh[i].Event = s.Event
 					hh[i].Stats = append(hh[i].Stats, Stat{
 						Day:          s.Day.Format("2006-01-02"),
 						Hourly:       x,

--- a/pack/pack.go
+++ b/pack/pack.go
@@ -471,6 +471,26 @@ commit;
 	insert into version values ('2020-05-18-1-domain-count');
 commit;
 `),
+	"db/migrate/pgsql/2020-05-23-1-event.sql": []byte(`begin;
+	update hits       set path=substr(path, 2) where event=1 and path like '/%';
+	update hit_counts set path=substr(path, 2) where event=1 and path like '/%';
+	update hit_stats  set path=substr(path, 2) where event=1 and path like '/%';
+
+	drop index "hit_counts#site#hour#event";
+	create index "hit_counts#site#hour" on hit_counts(site, hour);
+	alter table hit_counts drop constraint "hit_counts#site#path#hour#event";
+	alter table hit_counts add constraint "hit_counts#site#path#hour" unique(site, path, hour);
+
+	alter table hit_stats       drop column event;
+	alter table browser_stats   drop column event;
+	alter table system_stats    drop column event;
+	alter table location_stats  drop column event;
+	alter table ref_stats       drop column event;
+	alter table size_stats      drop column event;
+
+	insert into version values ('2020-05-23-1-event');
+commit;
+`),
 }
 
 var MigrationsSQLite = map[string][]byte{
@@ -1014,6 +1034,154 @@ commit;
 
 	insert into version values ('2020-05-18-1-domain-count');
 commit;
+`),
+	"db/migrate/sqlite/2020-05-23-1-event.sql": []byte(`begin;
+	update hits       set path=substr(path, 2) where event=1 and path like '/%';
+	update hit_counts set path=substr(path, 2) where event=1 and path like '/%';
+	update hit_stats  set path=substr(path, 2) where event=1 and path like '/%';
+
+	-- drop index "hit_counts#site#hour#event";
+	-- create index "hit_counts#site#hour" on hit_counts(site, hour);
+	-- alter table hit_counts drop constraint "hit_counts#site#path#hour#event";
+	-- alter table hit_counts add constraint "hit_counts#site#path#hour" unique(site, path, hour);
+	create table hit_counts2 (
+		site          int        not null check(site>0),
+		path          varchar    not null,
+		title         varchar    not null,
+		event         integer    not null default 0,
+		hour          timestamp  not null check(hour = strftime('%Y-%m-%d %H:%M:%S', hour)),
+		total         int        not null,
+		total_unique  int        not null,
+
+		constraint "hit_counts2#site#path#hour" unique(site, path, hour) on conflict replace
+	);
+	insert into hit_counts2 select
+		site, path, title, event, hour, total, total_unique
+	from hit_counts;
+	drop table hit_counts;
+	alter table hit_counts2 rename to hit_counts;
+	create index "hit_counts#site#hour" on hit_counts(site, hour);
+
+	-- alter table hit_stats       drop column event;
+	create table hit_stats2 (
+		site           integer        not null                 check(site > 0),
+
+		day            date           not null                 check(day = strftime('%Y-%m-%d', day)),
+		path           varchar        not null,
+		title          varchar        not null default '',
+		stats          varchar        not null,
+		stats_unique   varchar        not null,
+
+		foreign key (site) references sites(id) on delete restrict on update restrict
+	);
+	insert into hit_stats2 select
+		site, day, path, title, stats, stats_unique
+	from hit_stats;
+	drop table hit_stats;
+	alter table hit_stats2 rename to hit_stats;
+	create index "hit_stats#site#day" on hit_stats(site, day);
+
+	-- alter table browser_stats   drop column event;
+	create table browser_stats2 (
+		site           integer        not null                 check(site > 0),
+
+		day            date           not null                 check(day = strftime('%Y-%m-%d', day)),
+		browser        varchar        not null,
+		version        varchar        not null,
+		count          int            not null,
+		count_unique   int            not null,
+
+		foreign key (site) references sites(id) on delete restrict on update restrict
+	);
+	insert into browser_stats2 select
+		site, day, browser, version, count, count_unique
+	from browser_stats;
+	drop table browser_stats;
+	alter table browser_stats2 rename to browser_stats;
+	create index "browser_stats#site#day"         on browser_stats(site, day);
+	create index "browser_stats#site#day#browser" on browser_stats(site, day, browser);
+
+	-- alter table system_stats    drop column event;
+	create table system_stats2 (
+		site           integer        not null                 check(site > 0),
+
+		day            date           not null                 check(day = strftime('%Y-%m-%d', day)),
+		system         varchar        not null,
+		version        varchar        not null,
+		count          int            not null,
+		count_unique   int            not null,
+
+		foreign key (site) references sites(id) on delete restrict on update restrict
+	);
+	insert into system_stats2 select
+		site, day, system, version, count, count_unique
+	from system_stats;
+	drop table system_stats;
+	alter table system_stats2 rename to system_stats;
+	create index "system_stats#site#day"        on system_stats(site, day);
+	create index "system_stats#site#day#system" on system_stats(site, day, system);
+
+	-- alter table location_stats  drop column event;
+	create table location_stats2 (
+		site           integer        not null                 check(site > 0),
+
+		day            date           not null                 check(day = strftime('%Y-%m-%d', day)),
+		location       varchar        not null,
+		count          int            not null,
+		count_unique   int            not null,
+
+		foreign key (site) references sites(id) on delete restrict on update restrict
+	);
+	insert into location_stats2 select
+		site, day, location, count, count_unique
+	from location_stats;
+	drop table location_stats;
+	alter table location_stats2 rename to location_stats;
+	create index "location_stats#site#day"          on location_stats(site, day);
+	create index "location_stats#site#day#location" on location_stats(site, day, location);
+
+	-- alter table ref_stats       drop column event;
+	create table ref_stats2 (
+		site           integer        not null                 check(site > 0),
+
+		day            date           not null                 check(day = strftime('%Y-%m-%d', day)),
+		ref            varchar        not null,
+		count          int            not null,
+		count_unique   int            not null,
+
+		foreign key (site) references sites(id) on delete restrict on update restrict
+	);
+	insert into ref_stats2 select
+		site, day, ref, count, count_unique
+	from ref_stats;
+	drop table ref_stats;
+	alter table ref_stats2 rename to ref_stats;
+	create index "ref_stats#site#day" on ref_stats(site, day);
+
+	-- alter table size_stats      drop column event;
+	create table size_stats2 (
+		site           integer        not null                 check(site > 0),
+
+		day            date           not null                 check(day = strftime('%Y-%m-%d', day)),
+		width          int            not null,
+		count          int            not null,
+		count_unique   int            not null,
+
+		foreign key (site) references sites(id) on delete restrict on update restrict
+	);
+	insert into size_stats2 select
+		site, day, width, count, count_unique
+	from size_stats;
+	drop table size_stats;
+	alter table size_stats2 rename to size_stats;
+	create index "size_stats#site#day"       on size_stats(site, day);
+	create index "size_stats#site#day#width" on size_stats(site, day, width);
+
+
+	update hits set path=substr(path, 1) where event=1 and path like '/%';
+	insert into version values ('2020-05-23-1-event');
+commit;
+
 `),
 }
 


### PR DESCRIPTION
Since paths always start with a / this eliminates any conflicts
between events and paths, removing the need to store and group by it so
often.

There's only 1 hit which starts with / right now.