### PR TITLE
Add botlog

### DIFF
--- a/admin.go
+++ b/admin.go
@@ -5,15 +5,21 @@
 package goatcounter
 
 import (
+	"bytes"
 	"context"
 	"fmt"
+	"net/http"
+	"os/exec"
 	"sort"
 	"strings"
 	"time"
 
 	"zgo.at/errors"
 	"zgo.at/goatcounter/cfg"
+	"zgo.at/utils/jsonutil"
 	"zgo.at/zdb"
+	"zgo.at/zhttp"
+	"zgo.at/zlog"
 )
 
 type AdminStat struct {
@@ -363,5 +369,155 @@ func (a *AdminPgStatProgress) List(ctx context.Context) error {
 	`)
 
 	return errors.Wrap(err, "AdminPgStatProgress.List")
+}
 
+type AdminBotlog struct {
+	ID int64 `json:"id"`
+	IP int64 `json:"ip"`
+
+	Bot       int         `db:"bot"`
+	UserAgent string      `db:"ua"`
+	Headers   http.Header `db:"headers"`
+	URL       string      `db:"url"`
+}
+
+type AdminBotlogIP struct {
+	ID        int64     `db:"id"`
+	Count     int       `db:"count"`
+	IP        string    `db:"ip"`
+	PTR       *string   `db:"ptr"`
+	Info      *string   `db:"info"`
+	Hide      zdb.Bool  `db:"hide"`
+	CreatedAt time.Time `db:"created_at"`
+	LastSeen  time.Time `db:"last_seen"`
+
+	Links [][]string `db:"-"`
+}
+
+type AdminBotlogIPs []AdminBotlogIP
+
+func (b *AdminBotlogIPs) List(ctx context.Context) error {
+	err := zdb.MustGet(ctx).SelectContext(ctx, b,
+		`select * from botlog_ips where hide=0 order by count desc limit 100`)
+	if err != nil {
+		return errors.Wrap(err, "AdminBotlogIps.List")
+	}
+
+	bb := *b
+	for i := range bb {
+		if bb[i].Info == nil {
+			continue
+		}
+		t := strings.TrimSpace(*bb[i].Info)
+		bb[i].Info = &t
+		for _, line := range strings.Split(*bb[i].Info, "\n") {
+			if strings.HasPrefix(line, "org:") || strings.HasPrefix(line, "mnt-by:") || strings.HasPrefix(line, "netname:") {
+				bb[i].Links = append(bb[i].Links, strings.Fields(line))
+			}
+		}
+	}
+
+	return nil
+}
+
+func (b AdminBotlog) Insert(ctx context.Context, ip string) error {
+	ip = zhttp.RemovePort(ip)
+
+	txctx, tx, err := zdb.Begin(ctx)
+	if err != nil {
+		return fmt.Errorf("AdminBotlog.Insert Begin: %w", err)
+	}
+	defer tx.Rollback()
+
+	var (
+		ipID  int
+		newIP bool
+	)
+	err = tx.GetContext(txctx, &ipID, `select id from botlog_ips where ip=$1`, ip)
+	if err != nil && !zdb.ErrNoRows(err) {
+		return fmt.Errorf("AdminBotlog.Insert get IP: %w", err)
+	}
+
+	if ipID == 0 {
+		newIP = true
+		err := tx.GetContext(txctx, &ipID, `insert into botlog_ips
+			(ip, created_at, last_seen) values ($1, now(), now()) returning id`, ip)
+		if err != nil {
+			return fmt.Errorf("AdminBotlog.Insert insert ip: %w", err)
+		}
+	} else {
+		_, err := tx.ExecContext(txctx,
+			`update botlog_ips set count=count+1, last_seen=now() where id=$1`,
+			ipID)
+		if err != nil {
+			return fmt.Errorf("AdminBotlog.Insert update count: %w", err)
+		}
+	}
+
+	_, err = tx.ExecContext(txctx, `insert into botlog
+			(ip, bot, ua, headers, url, created_at) values ($1, $2, $3, $4, $5, now())`,
+		ipID, b.Bot, b.UserAgent, jsonutil.MustMarshal(b.Headers), b.URL)
+	if err != nil {
+		return fmt.Errorf("AdminBotlog.Insert botlog: %w", err)
+	}
+
+	err = tx.Commit()
+	if err != nil {
+		return fmt.Errorf("AdminBotlog.Insert commit: %w", err)
+	}
+
+	if newIP {
+		go func() {
+			defer zlog.Recover()
+
+			// apk add whois drill
+			whois, err := exec.Command("whois", "-r", "--", "--resource", ip).CombinedOutput()
+			if err != nil {
+				zlog.Fields(zlog.F{"ip": ip, "out": string(whois)}).Error(err)
+			}
+			var info strings.Builder
+			for _, line := range bytes.Split(bytes.TrimSpace(whois), []byte("\n")) {
+				if len(line) == 0 {
+					info.WriteRune('\n')
+					continue
+				}
+
+				if line[0] == '%' ||
+					bytes.HasPrefix(line, []byte("remarks:")) ||
+					bytes.HasPrefix(line, []byte("created:")) ||
+					bytes.HasPrefix(line, []byte("last-modified:")) {
+					continue
+				}
+			}
+
+			drill, err := exec.Command("drill", "-x", ip).CombinedOutput()
+			if err != nil {
+				zlog.Fields(zlog.F{"ip": ip, "out": string(whois)}).Error(err)
+			}
+
+			ptr := ""
+			lines := bytes.Split(drill, []byte("\n"))
+			for i, line := range lines {
+				if bytes.HasPrefix(line, []byte(";; ANSWER SECTION:")) {
+					answer := string(lines[i+1])
+					if !strings.Contains(answer, "PTR") {
+						ptr = "<not set>"
+					} else {
+						x := strings.Fields(answer)
+						ptr = x[len(x)-1]
+					}
+					break
+				}
+			}
+
+			_, err = zdb.MustGet(ctx).ExecContext(ctx,
+				`update botlog_ips set ptr=$1, info=$2 where id=$3`,
+				ptr, strings.TrimSpace(info.String()), ipID)
+			if err != nil {
+				zlog.Errorf("AdminBotlog.Insert: %w", err)
+			}
+		}()
+	}
+
+	return nil
 }

--- a/db/migrate/pgsql/2020-05-23-1-botlog.sql
+++ b/db/migrate/pgsql/2020-05-23-1-botlog.sql
@@ -1,0 +1,30 @@
+begin;
+	create table botlog_ips (
+		id             serial         primary key,
+
+		count          int            not null default 1,
+		ip             varchar        not null,
+		ptr            varchar,
+		info           varchar,
+		hide           int            default 0,
+
+		created_at     timestamp      not null,
+		last_seen      timestamp      not null
+	);
+	create unique index "botlog_ips#ip" on botlog_ips(ip);
+
+	create table botlog (
+		id             serial         primary key,
+
+		ip             int            not null,
+		bot            int            not null,
+		ua             varchar        not null,
+		headers        jsonb          not null,
+		url            varchar        not null,
+		created_at     timestamp      not null,
+
+		foreign key (ip) references botlog_ips(id)
+	);
+
+	insert into version values ('2020-05-23-1-botlog');
+commit;

--- a/handlers/admin.go
+++ b/handlers/admin.go
@@ -30,6 +30,7 @@ func (h admin) mount(r chi.Router) {
 
 	a.Get("/admin", zhttp.Wrap(h.admin))
 	a.Get("/admin/sql", zhttp.Wrap(h.adminSQL))
+	a.Get("/admin/botlog", zhttp.Wrap(h.adminBotlog))
 	a.Get("/admin/{id}", zhttp.Wrap(h.adminSite))
 
 	//aa.Get("/debug/pprof/*", pprof.Index)
@@ -163,6 +164,23 @@ func (h admin) adminSQL(w http.ResponseWriter, r *http.Request) error {
 		Progress goatcounter.AdminPgStatProgress
 	}{newGlobals(w, r), filter, load, string(free), stats, act, tbls,
 		idx, prog})
+}
+
+func (h admin) adminBotlog(w http.ResponseWriter, r *http.Request) error {
+	if goatcounter.MustGetSite(r.Context()).ID != 1 {
+		return guru.New(403, "yeah nah")
+	}
+
+	var ips goatcounter.AdminBotlogIPs
+	err := ips.List(r.Context())
+	if err != nil {
+		return err
+	}
+
+	return zhttp.Template(w, "backend_admin_botlog.gohtml", struct {
+		Globals
+		BotlogIP goatcounter.AdminBotlogIPs
+	}{newGlobals(w, r), ips})
 }
 
 func (h admin) adminSite(w http.ResponseWriter, r *http.Request) error {

--- a/handlers/backend.go
+++ b/handlers/backend.go
@@ -249,6 +249,24 @@ func (h backend) count(w http.ResponseWriter, r *http.Request) error {
 		hit.Bot = int(bot)
 	}
 
+	if uint8(hit.Bot) >= isbot.BotJSPhanton {
+		go func() {
+			defer zlog.Recover()
+			ctx := zdb.With(context.Background(), zdb.MustGet(r.Context()))
+
+			bl := goatcounter.AdminBotlog{
+				Bot:       hit.Bot,
+				UserAgent: r.UserAgent(),
+				Headers:   r.Header,
+				URL:       r.RequestURI,
+			}
+			err := bl.Insert(ctx, r.RemoteAddr)
+			if err != nil {
+				zlog.Error(err)
+			}
+		}()
+	}
+
 	// TODO: move to memstore?
 	{
 		var sess goatcounter.Session

--- a/tpl/backend_admin.gohtml
+++ b/tpl/backend_admin.gohtml
@@ -11,7 +11,11 @@ input    { float: right; padding: .4em !important; }
 </style>
 <style>.plan-free { background-color: #eaeaea; }</style>
 
-<p><a href="/debug/pprof">pprof</a> | <a href="/admin/sql">PostgreSQL</a></p>
+<p>
+	<a href="/debug/pprof">pprof</a> |
+	<a href="/admin/sql">PostgreSQL</a> |
+	<a href="/admin/botlog">Botlog</a>
+</p>
 
 <h2>Signups</h2>
 <div class="chart chart-bar">{{bar_chart $.Context .Signups .MaxSignups false}}</div>

--- a/tpl/backend_admin_botlog.gohtml
+++ b/tpl/backend_admin_botlog.gohtml
@@ -1,0 +1,49 @@
+{{template "_backend_top.gohtml" .}}
+
+<style>
+table    { max-width: none !important; }
+table table { max-width: 25em !important; }
+td       { white-space: nowrap; vertical-align: top; }
+pre      { white-space: pre-wrap; border: 0; background-color: transparent; margin: 0; }
+th       { text-align: left; }
+.n       { text-align: right; }
+input    { float: right; padding: .4em !important; }
+.sort th { color: blue; cursor: pointer; }
+</style>
+
+<h2>IPs</h2>
+<table>
+<thead><tr>
+	<th class="n">Count</th>
+	<th></th>
+	<th>whois</th>
+</thead>
+<tbody>
+	{{range $s := .BotlogIP}}
+	<tr>
+		<td class="n">{{$s.Count}}</td>
+		<td>
+			<table>
+			{{range $o := $s.Links}}
+				<tr>
+					<td>{{index $o 0}}</td>
+					<td><strong>{{index $o 1}}</strong>
+						<a href="https://search.arin.net/rdap/?query={{index $o 1}}">ARIN</a> |
+						<a href="https://apps.db.ripe.net/db-web-ui/query?rflag=true&searchtext={{index $o 1}}">RIPE</a>
+					</td>
+				</tr>
+			{{end}}
+			<tr><td>IP</td><td>{{$s.IP}}</td></tr>
+			<tr><td>PTR</td><td>{{$s.PTR}}</td></tr>
+			<tr><td>Create</td><td>{{$s.CreatedAt.Format "2006-01-02"}}</td></tr>
+			<tr><td>Last</td><td>{{$s.LastSeen.Format "2006-01-02"}}</td></tr>
+			<tr><td>ID</td><td>{{$s.ID}}</td></tr>
+			</table>
+		</td>
+		<td><pre>{{$s.Info}}</pre></td>
+	</tr>
+	{{end}}
+</tbody>
+</table>
+
+{{template "_backend_bottom.gohtml" .}}

--- a/tpl/backend_admin_sql.gohtml
+++ b/tpl/backend_admin_sql.gohtml
@@ -152,6 +152,4 @@ input    { float: right; padding: .4em !important; }
 </tbody>
 </table>
 
-
-
 {{template "_backend_bottom.gohtml" .}}

--- a/tpl/privacy.gohtml
+++ b/tpl/privacy.gohtml
@@ -18,6 +18,10 @@
 address, User-Agent, and a random number (“salt”) is stored for
 4 hours at the most to identify a browsing session.</p>
 
+<p>The exception to this are requests which are deemed to be coming from a bot,
+in which case the IP address will be stored temporarily for the purpose of
+blocking botnets, hosting providers, and other types of abuse.</p>
+
 <p>There is no information stored in the browser with e.g. cookies.</p>
 
 <p>Also see the <a href="/gdpr">GDPR consent notices</a>.</p>


### PR DESCRIPTION
Did with some CLI tools before, easier to block crap in isbot.

The theory here is that networks using bots we can detect are also using
bots we can't detect, and adding these IPs to isbot will also make
non-JS filtering more reliable.

This only works on PostgreSQL/saas mode.