### PR TITLE
fix(settings): add closing tag in the custom domain field description

### DIFF
--- a/tpl/backend_settings.gohtml
+++ b/tpl/backend_settings.gohtml
@@ -38,7 +38,7 @@
 						{{if not (.Site.PlanCustomDomain .Context)}}
 							Requires Personal Plus or Business plan (you’re
 							on the {{.Site.Plan}} plan; see
-							<a href="/billing">billing</a>.
+							<a href="/billing">billing</a>).
 						{{else}}
 							Set a CNAME record to <code>{{.Site.Code}}.{{.Domain}}</code>.
 							<a href="https://www.goatcounter.com/help#custom-domain" target="_blank">Detailed instructions</a>.


### PR DESCRIPTION
Here there's a closing tag missing after "billing":
![image](https://user-images.githubusercontent.com/15435678/83266434-1e768580-a1c3-11ea-8138-e241b0c88d0b.png)
