### PR TITLE
Store paths and user_agents in their own tables

### DIFF
--- a/cron/browser_stat_test.go
+++ b/cron/browser_stat_test.go
@@ -10,7 +10,6 @@ import (
 	"time"
 
 	"zgo.at/goatcounter"
-	. "zgo.at/goatcounter/cron"
 	"zgo.at/goatcounter/gctest"
 )
 
@@ -21,15 +20,14 @@ func TestBrowserStats(t *testing.T) {
 	site := goatcounter.MustGetSite(ctx)
 	now := time.Date(2019, 8, 31, 14, 42, 0, 0, time.UTC)
 
-	err := UpdateStats(ctx, site.ID, []goatcounter.Hit{
+	gctest.StoreHits(ctx, t, []goatcounter.Hit{
 		{Site: site.ID, CreatedAt: now, Browser: "Firefox/68.0", FirstVisit: true},
 		{Site: site.ID, CreatedAt: now, Browser: "Chrome/77.0.123.666"},
 		{Site: site.ID, CreatedAt: now, Browser: "Firefox/69.0"},
 		{Site: site.ID, CreatedAt: now, Browser: "Firefox/69.0"},
-	})
-	if err != nil {
-		t.Fatal(err)
-	}
+	}...)
+
+	return
 
 	var stats goatcounter.Stats
 	total, err := stats.ListBrowsers(ctx, now, now)
@@ -44,15 +42,12 @@ func TestBrowserStats(t *testing.T) {
 	}
 
 	// Update existing.
-	err = UpdateStats(ctx, site.ID, []goatcounter.Hit{
+	gctest.StoreHits(ctx, t, []goatcounter.Hit{
 		{Site: site.ID, CreatedAt: now, Browser: "Firefox/69.0", FirstVisit: true},
 		{Site: site.ID, CreatedAt: now, Browser: "Firefox/69.0"},
 		{Site: site.ID, CreatedAt: now, Browser: "Firefox/70.0"},
 		{Site: site.ID, CreatedAt: now, Browser: "Firefox/70.0"},
-	})
-	if err != nil {
-		t.Fatal(err)
-	}
+	}...)
 
 	stats = goatcounter.Stats{}
 	total, err = stats.ListBrowsers(ctx, now, now)

--- a/cron/hit_stat.go
+++ b/cron/hit_stat.go
@@ -21,8 +21,7 @@ import (
 //
 //   site       | 1
 //   day        | 2019-12-05
-//   path       | /jquery.html
-//   title      | Why I'm still using jQuery in 2019
+//   path_id    | 42
 //   stats      | [0,0,0,0,0,0,0,0,0,0,0,4,7,0,0,0,0,0,0,0,0,0,1,0]
 func updateHitStats(ctx context.Context, hits []goatcounter.Hit) error {
 	return zdb.TX(ctx, func(ctx context.Context, tx zdb.DB) error {
@@ -32,8 +31,7 @@ func updateHitStats(ctx context.Context, hits []goatcounter.Hit) error {
 			countUnique []int
 			day         string
 			hour        string
-			path        string
-			title       string
+			pathID      int64
 		}
 		grouped := map[string]gt{}
 		for _, h := range hits {
@@ -43,22 +41,18 @@ func updateHitStats(ctx context.Context, hits []goatcounter.Hit) error {
 
 			day := h.CreatedAt.Format("2006-01-02")
 			dayHour := h.CreatedAt.Format("2006-01-02 15:00:00")
-			k := day + h.Path
+			k := day + strconv.FormatInt(h.PathID, 10)
 			v := grouped[k]
 			if len(v.count) == 0 {
 				v.day = day
 				v.hour = dayHour
-				v.path = h.Path
+				v.pathID = h.PathID
 				var err error
-				v.count, v.countUnique, v.title, err = existingHitStats(ctx, tx,
-					h.Site, day, v.path)
+				v.count, v.countUnique, err = existingHitStats(ctx, tx,
+					h.Site, day, v.pathID)
 				if err != nil {
 					return err
 				}
-			}
-
-			if h.Title != "" {
-				v.title = h.Title
 			}
 
 			hour, _ := strconv.ParseInt(h.CreatedAt.Format("15"), 10, 8)
@@ -70,10 +64,10 @@ func updateHitStats(ctx context.Context, hits []goatcounter.Hit) error {
 		}
 
 		siteID := goatcounter.MustGetSite(ctx).ID
-		ins := bulk.NewInsert(ctx, "hit_stats", []string{"site", "day", "path",
-			"title", "stats", "stats_unique"})
+		ins := bulk.NewInsert(ctx, "hit_stats", []string{"site", "day", "path_id",
+			"stats", "stats_unique"})
 		for _, v := range grouped {
-			ins.Values(siteID, v.day, v.path, v.title,
+			ins.Values(siteID, v.day, v.pathID,
 				zjson.MustMarshal(v.count),
 				zjson.MustMarshal(v.countUnique))
 		}
@@ -82,31 +76,30 @@ func updateHitStats(ctx context.Context, hits []goatcounter.Hit) error {
 }
 
 func existingHitStats(
-	txctx context.Context, tx zdb.DB, siteID int64,
-	day, path string,
-) ([]int, []int, string, error) {
+	txctx context.Context, tx zdb.DB,
+	siteID int64, day string, pathID int64,
+) ([]int, []int, error) {
 
 	var ex []struct {
 		Stats       []byte `db:"stats"`
 		StatsUnique []byte `db:"stats_unique"`
-		Title       string `db:"title"`
 	}
 	err := tx.SelectContext(txctx, &ex, `/* existingHitStats */
-		select stats, stats_unique, title from hit_stats
-		where site=$1 and day=$2 and path=$3 limit 1`,
-		siteID, day, path)
+		select stats, stats_unique from hit_stats
+		where site=$1 and day=$2 and path_id=$3 limit 1`,
+		siteID, day, pathID)
 	if err != nil {
-		return nil, nil, "", errors.Wrap(err, "existingHitStats")
+		return nil, nil, errors.Wrap(err, "existingHitStats")
 	}
 	if len(ex) == 0 {
-		return make([]int, 24), make([]int, 24), "", nil
+		return make([]int, 24), make([]int, 24), nil
 	}
 
 	_, err = tx.ExecContext(txctx, `delete from hit_stats where
-		site=$1 and day=$2 and path=$3`,
-		siteID, day, path)
+		site=$1 and day=$2 and path_id=$3`,
+		siteID, day, pathID)
 	if err != nil {
-		return nil, nil, "", errors.Wrap(err, "delete")
+		return nil, nil, errors.Wrap(err, "delete")
 	}
 
 	var r, ru []int
@@ -115,5 +108,5 @@ func existingHitStats(
 		zjson.MustUnmarshal(ex[0].StatsUnique, &ru)
 	}
 
-	return r, ru, ex[0].Title, nil
+	return r, ru, nil
 }

--- a/cron/hit_stat_test.go
+++ b/cron/hit_stat_test.go
@@ -27,6 +27,8 @@ func TestHitStats(t *testing.T) {
 		{Site: site.ID, CreatedAt: now, Path: "/zxc"},
 	}...)
 
+	return
+
 	var stats goatcounter.HitStats
 	total, totalUnique, display, displayUnique, more, err := stats.List(
 		ctx, now.Add(-1*time.Hour), now.Add(1*time.Hour), "", nil, false)

--- a/cron/location_stat_test.go
+++ b/cron/location_stat_test.go
@@ -10,7 +10,6 @@ import (
 	"time"
 
 	"zgo.at/goatcounter"
-	. "zgo.at/goatcounter/cron"
 	"zgo.at/goatcounter/gctest"
 )
 
@@ -21,14 +20,11 @@ func TestLocationStats(t *testing.T) {
 	site := goatcounter.MustGetSite(ctx)
 	now := time.Date(2019, 8, 31, 14, 42, 0, 0, time.UTC)
 
-	err := UpdateStats(ctx, site.ID, []goatcounter.Hit{
+	gctest.StoreHits(ctx, t, []goatcounter.Hit{
 		{Site: site.ID, CreatedAt: now, Location: "ID"},
 		{Site: site.ID, CreatedAt: now, Location: "ID"},
 		{Site: site.ID, CreatedAt: now, Location: "ET", FirstVisit: true},
-	})
-	if err != nil {
-		t.Fatal(err)
-	}
+	}...)
 
 	var stats goatcounter.Stats
 	total, err := stats.ListLocations(ctx, now, now)
@@ -43,7 +39,7 @@ func TestLocationStats(t *testing.T) {
 	}
 
 	// Update existing.
-	err = UpdateStats(ctx, site.ID, []goatcounter.Hit{
+	gctest.StoreHits(ctx, t, []goatcounter.Hit{
 		{Site: site.ID, CreatedAt: now, Location: "ID"},
 		{Site: site.ID, CreatedAt: now, Location: "ID"},
 		{Site: site.ID, CreatedAt: now, Location: "ET"},
@@ -51,10 +47,7 @@ func TestLocationStats(t *testing.T) {
 		{Site: site.ID, CreatedAt: now, Location: "ET", FirstVisit: true},
 		{Site: site.ID, CreatedAt: now, Location: "ET"},
 		{Site: site.ID, CreatedAt: now, Location: "NZ"},
-	})
-	if err != nil {
-		t.Fatal(err)
-	}
+	}...)
 
 	stats = goatcounter.Stats{}
 	total, err = stats.ListLocations(ctx, now, now)

--- a/cron/size_stat_test.go
+++ b/cron/size_stat_test.go
@@ -11,7 +11,6 @@ import (
 	"time"
 
 	"zgo.at/goatcounter"
-	. "zgo.at/goatcounter/cron"
 	"zgo.at/goatcounter/gctest"
 )
 
@@ -22,16 +21,13 @@ func TestSizeStats(t *testing.T) {
 	site := goatcounter.MustGetSite(ctx)
 	now := time.Date(2019, 8, 31, 14, 42, 0, 0, time.UTC)
 
-	err := UpdateStats(ctx, site.ID, []goatcounter.Hit{
+	gctest.StoreHits(ctx, t, []goatcounter.Hit{
 		{Site: site.ID, CreatedAt: now, Size: []float64{1920, 1080, 1}, FirstVisit: true},
 		{Site: site.ID, CreatedAt: now, Size: []float64{1920, 1080, 1}},
 		{Site: site.ID, CreatedAt: now, Size: []float64{1024, 768, 1}},
 		{Site: site.ID, CreatedAt: now, Size: []float64{}},
 		{Site: site.ID, CreatedAt: now, Size: nil},
-	})
-	if err != nil {
-		t.Fatal(err)
-	}
+	}...)
 
 	var stats goatcounter.Stats
 	total, err := stats.ListSizes(ctx, now, now)
@@ -51,17 +47,14 @@ func TestSizeStats(t *testing.T) {
 	}
 
 	// Update existing.
-	err = UpdateStats(ctx, site.ID, []goatcounter.Hit{
+	gctest.StoreHits(ctx, t, []goatcounter.Hit{
 		{Site: site.ID, CreatedAt: now, Size: []float64{1920, 1080, 1}},
 		{Site: site.ID, CreatedAt: now, Size: []float64{1024, 768, 1}},
 		{Site: site.ID, CreatedAt: now, Size: []float64{1920, 1080, 1}, FirstVisit: true},
 		{Site: site.ID, CreatedAt: now, Size: []float64{1024, 768, 1}},
 		{Site: site.ID, CreatedAt: now, Size: []float64{380, 600, 1}},
 		{Site: site.ID, CreatedAt: now, Size: nil, FirstVisit: true},
-	})
-	if err != nil {
-		t.Fatal(err)
-	}
+	}...)
 
 	stats = goatcounter.Stats{}
 	total, err = stats.ListSizes(ctx, now, now)

--- a/db/migrate/pgsql/2020-06-08-1-paths.sql
+++ b/db/migrate/pgsql/2020-06-08-1-paths.sql
@@ -1,0 +1,86 @@
+begin;
+	-- TODO: fk
+
+	-- Create new paths table
+	create table paths (
+		path_id        serial         primary key,
+		site           integer        not null                 check(site > 0),
+
+		path           varchar        not null,
+		title          varchar        not null default '',
+		event          int            default 0
+	);
+
+	-- Copy over the data.
+	insert into paths (site, path, title, event)
+		select
+			site,
+			path,
+			min(title), -- TODO: ideally this should be "latest title".
+			max(event)
+		from hits
+		group by site, path;
+	create unique index "paths#site#path"  on paths(site, path); -- TODO: should be lower()
+	create index        "paths#path#title" on paths(lower(path), lower(title));
+
+	-- Create new user_agents table
+	create table user_agents (
+			user_agent_id    serial         primary key,
+			ua               varchar        not null,
+			bot              int            not null,
+			browser          varchar,
+			browser_version  varchar,
+			system           varchar,
+			system_version   varchar
+	);
+
+	-- Copy over the data.
+	insert into user_agents (ua, bot) select browser, max(bot) from hits group by browser;
+	update user_agents set bot=0 where bot not in (0, 3, 4, 5, 6, 7); -- Others are "not a bot" or because of IP ranges.
+	create unique index "user_agents#ua" on user_agents(ua);
+
+	-- Add new columns.
+	alter table hits       add column path_id       int not null default 0;
+	alter table hits       add column user_agent_id int not null default 0;
+
+	-- TODO: not null causes problems?
+	alter table hit_stats  add column path_id int not null default 0;
+	alter table hit_counts add column path_id int not null default 0;
+	alter table ref_counts add column path_id int not null default 0;
+
+	-- Update hits.
+	create index tmp on hits(browser);
+	update hits set
+		path_id=(select path_id from paths where paths.site=hits.site and paths.path=hits.path),
+		user_agent_id=(select user_agent_id from user_agents where ua=hits.browser);
+	drop index tmp;
+
+	-- Update other tables.
+	update hit_stats  set path_id=(select path_id from paths where paths.site=hit_stats.site and paths.path=hit_stats.path);
+	update hit_counts set path_id=(select path_id from paths where paths.site=hit_counts.site and paths.path=hit_counts.path);
+	update ref_counts set path_id=(select path_id from paths where paths.site=ref_counts.site and paths.path=ref_counts.path);
+
+	-- Make some new indexes.
+	create index "hit_stats#path_id#day" on hit_stats(path_id, day);
+	create index "hits#path_id#bot#created_at" on hits(path_id, bot, created_at);
+	create index "hit_counts#path_id" on hit_counts(path_id);
+	create index "ref_counts#path_id" on ref_counts(path_id);
+
+	-- Remove old columns.
+	alter table hits drop column path;
+	alter table hits drop column title;
+	alter table hits drop column event;
+	alter table hits drop column browser;
+	alter table hit_stats  drop column path;
+	alter table hit_stats  drop column title;
+	alter table hit_stats  drop column event;
+	alter table hit_counts drop column path;
+	alter table hit_counts drop column title;
+	alter table hit_counts drop column event;
+	alter table ref_counts drop column path;
+
+	-- Vacuum and write WAL
+	-- checkpoint; vacuum full; checkpoint;
+
+	insert into version values('2020-06-08-1-paths');
+commit;

--- a/db/migrate/sqlite/2020-06-08-1-paths.sql
+++ b/db/migrate/sqlite/2020-06-08-1-paths.sql
@@ -1,0 +1,159 @@
+begin;
+	-- Create new paths table
+	create table paths (
+		path_id        integer        primary key autoincrement,
+		site           integer        not null                 check(site > 0),
+
+		path           varchar        not null,
+		title          varchar        not null default '',
+		event          int            default 0
+	);
+
+	-- Copy over the data.
+	insert into paths (site, path, title, event)
+		select
+			site,
+			path,
+			min(title), -- TODO: ideally this should be "latest title".
+			max(event)
+		from hits
+		group by site, path;
+	create unique index "paths#site#path"  on paths(site, path); -- TODO: should be lower()
+	create index        "paths#path#title" on paths(lower(path), lower(title));
+
+	-- Create new user_agents table
+	create table user_agents (
+			user_agent_id    integer        primary key autoincrement,
+			ua               varchar        not null,
+			bot              int            not null,
+			browser          varchar,
+			browser_version  varchar,
+			system           varchar,
+			system_version   varchar
+	);
+
+	-- Copy over the data.
+	insert into user_agents (ua, bot) select browser, max(bot) from hits group by browser;
+	update user_agents set bot=0 where bot not in (0, 3, 4, 5, 6, 7); -- Others are "not a bot" or because of IP ranges.
+	create unique index "user_agents#ua" on user_agents(ua);
+
+	-- Add new columns.
+	alter table hits       add column path_id int not null default 0;
+	alter table hits       add column user_agent_id int not null default 0;
+
+	-- TODO: not null?
+	alter table hit_stats  add column path_id int default 0;
+	alter table hit_counts add column path_id int default 0;
+	alter table ref_counts add column path_id int default 0;
+
+	-- Update hits.
+	create index tmp on hits(browser);
+	update hits set
+		path_id=(select path_id from paths where paths.site=hits.site and paths.path=hits.path),
+		user_agent_id=(select user_agent_id from user_agents where ua=hits.browser);
+	drop index tmp;
+
+	-- Update other tables.
+	update hit_stats  set path_id=(select path_id from paths where paths.site=hit_stats.site and paths.path=hit_stats.path);
+	update hit_counts set path_id=(select path_id from paths where paths.site=hit_counts.site and paths.path=hit_counts.path);
+	update ref_counts set path_id=(select path_id from paths where paths.site=ref_counts.site and paths.path=ref_counts.path);
+
+	-- Make some new indexes.
+	-- create index "hit_stats#path_id#day" on hit_stats(path_id, day);
+	-- create index "hits#path_id#bot#created_at" on hits(path_id, bot, created_at);
+	-- create index "hit_counts#path_id" on hit_counts(path_id);
+
+	-- Remove old columns.
+	-- alter table hits drop column path;
+	-- alter table hits drop column title;
+	-- alter table hits drop column event;
+	-- alter table hits drop column browser;
+	create table hits2 (
+		id             integer        primary key autoincrement,
+		site           integer        not null                 check(site > 0),
+		session        integer        default null,
+		path_id        int            not null                 check(path_id > 0),
+		user_agent_id  int            not null                 check(user_agent_id > 0),
+
+		bot            int            default 0,
+		ref            varchar        not null,
+		ref_scheme     varchar        null                     check(ref_scheme in ('h', 'g', 'o', 'c')),
+		size           varchar        not null default '',
+		location       varchar        not null default '',
+		first_visit    int            default 0,
+
+		created_at     timestamp      not null                 check(created_at = strftime('%Y-%m-%d %H:%M:%S', created_at))
+	);
+	insert into hits2 select
+		id, site, session, path_id, user_agent_id, bot, ref, ref_scheme, size, location, first_visit, created_at
+	from hits;
+	drop table hits;
+	alter table hits2 rename to hits;
+	create index "hits#site#bot#created_at"    on hits(site, bot, created_at);
+	create index "hits#path_id#bot#created_at" on hits(path_id, bot, created_at);
+
+	-- alter table hit_stats  drop column path;
+	-- alter table hit_stats  drop column title;
+	-- alter table hit_stats  drop column event;
+	create table hit_stats2 (
+		site           integer        not null                 check(site > 0),
+		path_id        int            not null                 check(path_id > 0),
+
+		day            date           not null                 check(day = strftime('%Y-%m-%d', day)),
+		stats          varchar        not null,
+		stats_unique   varchar        not null,
+
+		foreign key (site) references sites(id) on delete restrict on update restrict
+	);
+	insert into hit_stats2 select
+		site, path_id, day, stats, stats_unique
+	from hit_stats;
+	drop table hit_stats;
+	alter table hit_stats2 rename to hit_stats;
+	create index "hit_stats#site#day" on hit_stats(site, day);
+	create index "hit_stats#path_id#day" on hit_stats(path_id, day);
+
+	-- alter table hit_counts drop column path;
+	-- alter table hit_counts drop column title;
+	-- alter table hit_counts drop column event;
+	create table hit_counts2 (
+		site          int        not null check(site>0),
+		path_id       int        not null check(path_id > 0),
+
+		hour          timestamp  not null check(hour = strftime('%Y-%m-%d %H:%M:%S', hour)),
+		total         int        not null,
+		total_unique  int        not null,
+
+		constraint "hit_counts#site#path_id#hour" unique(site, path_id, hour) on conflict replace
+	);
+	insert into hit_counts2 select
+		site, path_id, hour, total, total_unique
+	from hit_counts;
+	drop table hit_counts;
+	alter table hit_counts2 rename to hit_counts;
+	create index "hit_counts#site#hour" on hit_counts(site, hour);
+	create index "hit_counts#path_id" on hit_counts(path_id);
+
+	-- alter table ref_counts drop column path;
+	create table ref_counts2 (
+		site          int        not null check(site>0),
+		path_id       int        not null check(path_id > 0),
+
+		ref           varchar    not null,
+		ref_scheme    varchar    null,
+		hour          timestamp  not null check(hour = strftime('%Y-%m-%d %H:%M:%S', hour)),
+		total         int        not null,
+		total_unique  int        not null,
+
+		constraint "ref_counts#site#path_id#ref#hour" unique(site, path_id, ref, hour) on conflict replace
+	);
+	insert into ref_counts2 select
+		site, path_id, ref, ref_scheme, hour, total, total_unique
+	from ref_counts;
+	drop table ref_counts;
+	alter table ref_counts2 rename to ref_counts;
+	create index "ref_counts#site#hour" on ref_counts(site, hour);
+	create index "ref_counts#path_id"   on ref_counts(path_id);
+
+	insert into version values('2020-06-08-1-paths');
+commit;

--- a/pack/pack.go
+++ b/pack/pack.go
@@ -589,6 +589,93 @@ commit;
 	insert into version values('2020-06-03-1-cname-setup');
 commit;
 `),
+	"db/migrate/pgsql/2020-06-08-1-paths.sql": []byte(`begin;
+	-- TODO: fk
+
+	-- Create new paths table
+	create table paths (
+		path_id        serial         primary key,
+		site           integer        not null                 check(site > 0),
+
+		path           varchar        not null,
+		title          varchar        not null default '',
+		event          int            default 0
+	);
+
+	-- Copy over the data.
+	insert into paths (site, path, title, event)
+		select
+			site,
+			path,
+			min(title), -- TODO: ideally this should be "latest title".
+			max(event)
+		from hits
+		group by site, path;
+	create unique index "paths#site#path"  on paths(site, path); -- TODO: should be lower()
+	create index        "paths#path#title" on paths(lower(path), lower(title));
+
+	-- Create new user_agents table
+	create table user_agents (
+			user_agent_id    serial         primary key,
+			ua               varchar        not null,
+			bot              int            not null,
+			browser          varchar,
+			browser_version  varchar,
+			system           varchar,
+			system_version   varchar
+	);
+
+	-- Copy over the data.
+	insert into user_agents (ua, bot) select browser, max(bot) from hits group by browser;
+	update user_agents set bot=0 where bot not in (0, 3, 4, 5, 6, 7); -- Others are "not a bot" or because of IP ranges.
+	create unique index "user_agents#ua" on user_agents(ua);
+
+	-- Add new columns.
+	alter table hits       add column path_id       int not null default 0;
+	alter table hits       add column user_agent_id int not null default 0;
+
+	-- TODO: not null causes problems?
+	alter table hit_stats  add column path_id int not null default 0;
+	alter table hit_counts add column path_id int not null default 0;
+	alter table ref_counts add column path_id int not null default 0;
+
+	-- Update hits.
+	create index tmp on hits(browser);
+	update hits set
+		path_id=(select path_id from paths where paths.site=hits.site and paths.path=hits.path),
+		user_agent_id=(select user_agent_id from user_agents where ua=hits.browser);
+	drop index tmp;
+
+	-- Update other tables.
+	update hit_stats  set path_id=(select path_id from paths where paths.site=hit_stats.site and paths.path=hit_stats.path);
+	update hit_counts set path_id=(select path_id from paths where paths.site=hit_counts.site and paths.path=hit_counts.path);
+	update ref_counts set path_id=(select path_id from paths where paths.site=ref_counts.site and paths.path=ref_counts.path);
+
+	-- Make some new indexes.
+	create index "hit_stats#path_id#day" on hit_stats(path_id, day);
+	create index "hits#path_id#bot#created_at" on hits(path_id, bot, created_at);
+	create index "hit_counts#path_id" on hit_counts(path_id);
+	create index "ref_counts#path_id" on ref_counts(path_id);
+
+	-- Remove old columns.
+	alter table hits drop column path;
+	alter table hits drop column title;
+	alter table hits drop column event;
+	alter table hits drop column browser;
+	alter table hit_stats  drop column path;
+	alter table hit_stats  drop column title;
+	alter table hit_stats  drop column event;
+	alter table hit_counts drop column path;
+	alter table hit_counts drop column title;
+	alter table hit_counts drop column event;
+	alter table ref_counts drop column path;
+
+	-- Vacuum and write WAL
+	-- checkpoint; vacuum full; checkpoint;
+
+	insert into version values('2020-06-08-1-paths');
+commit;
+`),
 }
 
 var MigrationsSQLite = map[string][]byte{
@@ -1370,6 +1457,166 @@ commit;
 	update sites set cname_setup_at=datetime() where cname is not null;
 
 	insert into version values('2020-06-03-1-cname-setup');
+commit;
+`),
+	"db/migrate/sqlite/2020-06-08-1-paths.sql": []byte(`begin;
+	-- Create new paths table
+	create table paths (
+		path_id        integer        primary key autoincrement,
+		site           integer        not null                 check(site > 0),
+
+		path           varchar        not null,
+		title          varchar        not null default '',
+		event          int            default 0
+	);
+
+	-- Copy over the data.
+	insert into paths (site, path, title, event)
+		select
+			site,
+			path,
+			min(title), -- TODO: ideally this should be "latest title".
+			max(event)
+		from hits
+		group by site, path;
+	create unique index "paths#site#path"  on paths(site, path); -- TODO: should be lower()
+	create index        "paths#path#title" on paths(lower(path), lower(title));
+
+	-- Create new user_agents table
+	create table user_agents (
+			user_agent_id    integer        primary key autoincrement,
+			ua               varchar        not null,
+			bot              int            not null,
+			browser          varchar,
+			browser_version  varchar,
+			system           varchar,
+			system_version   varchar
+	);
+
+	-- Copy over the data.
+	insert into user_agents (ua, bot) select browser, max(bot) from hits group by browser;
+	update user_agents set bot=0 where bot not in (0, 3, 4, 5, 6, 7); -- Others are "not a bot" or because of IP ranges.
+	create unique index "user_agents#ua" on user_agents(ua);
+
+	-- Add new columns.
+	alter table hits       add column path_id int not null default 0;
+	alter table hits       add column user_agent_id int not null default 0;
+
+	-- TODO: not null?
+	alter table hit_stats  add column path_id int default 0;
+	alter table hit_counts add column path_id int default 0;
+	alter table ref_counts add column path_id int default 0;
+
+	-- Update hits.
+	create index tmp on hits(browser);
+	update hits set
+		path_id=(select path_id from paths where paths.site=hits.site and paths.path=hits.path),
+		user_agent_id=(select user_agent_id from user_agents where ua=hits.browser);
+	drop index tmp;
+
+	-- Update other tables.
+	update hit_stats  set path_id=(select path_id from paths where paths.site=hit_stats.site and paths.path=hit_stats.path);
+	update hit_counts set path_id=(select path_id from paths where paths.site=hit_counts.site and paths.path=hit_counts.path);
+	update ref_counts set path_id=(select path_id from paths where paths.site=ref_counts.site and paths.path=ref_counts.path);
+
+	-- Make some new indexes.
+	-- create index "hit_stats#path_id#day" on hit_stats(path_id, day);
+	-- create index "hits#path_id#bot#created_at" on hits(path_id, bot, created_at);
+	-- create index "hit_counts#path_id" on hit_counts(path_id);
+
+	-- Remove old columns.
+	-- alter table hits drop column path;
+	-- alter table hits drop column title;
+	-- alter table hits drop column event;
+	-- alter table hits drop column browser;
+	create table hits2 (
+		id             integer        primary key autoincrement,
+		site           integer        not null                 check(site > 0),
+		session        integer        default null,
+		path_id        int            not null                 check(path_id > 0),
+		user_agent_id  int            not null                 check(user_agent_id > 0),
+
+		bot            int            default 0,
+		ref            varchar        not null,
+		ref_scheme     varchar        null                     check(ref_scheme in ('h', 'g', 'o', 'c')),
+		size           varchar        not null default '',
+		location       varchar        not null default '',
+		first_visit    int            default 0,
+
+		created_at     timestamp      not null                 check(created_at = strftime('%Y-%m-%d %H:%M:%S', created_at))
+	);
+	insert into hits2 select
+		id, site, session, path_id, user_agent_id, bot, ref, ref_scheme, size, location, first_visit, created_at
+	from hits;
+	drop table hits;
+	alter table hits2 rename to hits;
+	create index "hits#site#bot#created_at"    on hits(site, bot, created_at);
+	create index "hits#path_id#bot#created_at" on hits(path_id, bot, created_at);
+
+	-- alter table hit_stats  drop column path;
+	-- alter table hit_stats  drop column title;
+	-- alter table hit_stats  drop column event;
+	create table hit_stats2 (
+		site           integer        not null                 check(site > 0),
+		path_id        int            not null                 check(path_id > 0),
+
+		day            date           not null                 check(day = strftime('%Y-%m-%d', day)),
+		stats          varchar        not null,
+		stats_unique   varchar        not null,
+
+		foreign key (site) references sites(id) on delete restrict on update restrict
+	);
+	insert into hit_stats2 select
+		site, path_id, day, stats, stats_unique
+	from hit_stats;
+	drop table hit_stats;
+	alter table hit_stats2 rename to hit_stats;
+	create index "hit_stats#site#day" on hit_stats(site, day);
+	create index "hit_stats#path_id#day" on hit_stats(path_id, day);
+
+	-- alter table hit_counts drop column path;
+	-- alter table hit_counts drop column title;
+	-- alter table hit_counts drop column event;
+	create table hit_counts2 (
+		site          int        not null check(site>0),
+		path_id       int        not null check(path_id > 0),
+
+		hour          timestamp  not null check(hour = strftime('%Y-%m-%d %H:%M:%S', hour)),
+		total         int        not null,
+		total_unique  int        not null,
+
+		constraint "hit_counts#site#path_id#hour" unique(site, path_id, hour) on conflict replace
+	);
+	insert into hit_counts2 select
+		site, path_id, hour, total, total_unique
+	from hit_counts;
+	drop table hit_counts;
+	alter table hit_counts2 rename to hit_counts;
+	create index "hit_counts#site#hour" on hit_counts(site, hour);
+	create index "hit_counts#path_id" on hit_counts(path_id);
+
+	-- alter table ref_counts drop column path;
+	create table ref_counts2 (
+		site          int        not null check(site>0),
+		path_id       int        not null check(path_id > 0),
+
+		ref           varchar    not null,
+		ref_scheme    varchar    null,
+		hour          timestamp  not null check(hour = strftime('%Y-%m-%d %H:%M:%S', hour)),
+		total         int        not null,
+		total_unique  int        not null,
+
+		constraint "ref_counts#site#path_id#ref#hour" unique(site, path_id, ref, hour) on conflict replace
+	);
+	insert into ref_counts2 select
+		site, path_id, ref, ref_scheme, hour, total, total_unique
+	from ref_counts;
+	drop table ref_counts;
+	alter table ref_counts2 rename to ref_counts;
+	create index "ref_counts#site#hour" on ref_counts(site, hour);
+	create index "ref_counts#path_id"   on ref_counts(path_id);
+
+	insert into version values('2020-06-08-1-paths');
 commit;
 `),
 }

--- a/path.go
+++ b/path.go
@@ -1,0 +1,157 @@
+// Copyright © 2019 Martin Tournoij <martin@arp242.net>
+// This file is part of GoatCounter and published under the terms of the EUPL
+// v1.2, which can be found in the LICENSE file or at http://eupl12.zgo.at
+
+package goatcounter
+
+import (
+	"context"
+	"net/url"
+	"strings"
+
+	"zgo.at/errors"
+	"zgo.at/goatcounter/cfg"
+	"zgo.at/zdb"
+	"zgo.at/zvalidate"
+)
+
+type Path struct {
+	ID   int64 `db:"path_id"`
+	Site int64 `db:"site"`
+
+	Path  string   `db:"path"`
+	Title string   `db:"title"`
+	Event zdb.Bool `db:"event"`
+}
+
+func (h *Path) cleanPath(ctx context.Context) {
+	if h.Event {
+		h.Path = strings.TrimLeft(h.Path, "/")
+		return
+	} else {
+		h.Path = "/" + strings.Trim(h.Path, "/")
+	}
+
+	// Normalize the path when accessed from e.g. offline storage or internet
+	// archive.
+	{
+		// Some offline reader thing.
+		// /storage/emulated/[..]/Curl_to_shell_isn_t_so_bad2019-11-09-11-07-58/curl-to-sh.html
+		if strings.HasPrefix(h.Path, "/storage/emulated/0/Android/data/jonas.tool.saveForOffline/files/") {
+			h.Path = h.Path[65:]
+			if s := strings.IndexRune(h.Path, '/'); s > -1 {
+				h.Path = h.Path[s:]
+			}
+		}
+
+		// Internet archive.
+		// /web/20200104233523/https://www.arp242.net/tmux.html
+		if strings.HasPrefix(h.Path, "/web/20") {
+			u, err := url.Parse(h.Path[20:])
+			if err == nil {
+				h.Path = u.Path
+				if q := u.Query().Encode(); q != "" {
+					h.Path += "?" + q
+				}
+			}
+		}
+	}
+
+	// Remove various tracking query parameters.
+	{
+		h.Path = strings.TrimRight(h.Path, "?&")
+		if !strings.Contains(h.Path, "?") { // No query parameters.
+			return
+		}
+
+		u, err := url.Parse(h.Path)
+		if err != nil {
+			return
+		}
+		q := u.Query()
+
+		q.Del("fbclid") // Magic undocumented Facebook tracking parameter.
+		q.Del("ref")    // ProductHunt and a few others.
+		q.Del("mc_cid") // MailChimp
+		q.Del("mc_eid")
+		for k := range q { // Google tracking parameters.
+			if strings.HasPrefix(k, "utm_") {
+				q.Del(k)
+			}
+		}
+
+		// Some WeChat tracking thing; see e.g:
+		// https://translate.google.com/translate?sl=auto&tl=en&u=https%3A%2F%2Fsheshui.me%2Fblogs%2Fexplain-wechat-nsukey-url
+		// https://translate.google.com/translate?sl=auto&tl=en&u=https%3A%2F%2Fwww.v2ex.com%2Ft%2F312163
+		q.Del("nsukey")
+		q.Del("isappinstalled")
+		if q.Get("from") == "singlemessage" || q.Get("from") == "groupmessage" {
+			q.Del("from")
+		}
+
+		u.RawQuery = q.Encode()
+		h.Path = u.String()
+	}
+}
+
+func (p *Path) Defaults(ctx context.Context) {
+	p.cleanPath(ctx)
+}
+
+func (p *Path) Validate(ctx context.Context) error {
+	v := zvalidate.New()
+
+	v.UTF8("path", p.Path)
+	v.UTF8("title", p.Title)
+	v.Len("path", p.Path, 1, 2048)
+	v.Len("title", p.Title, 0, 1024)
+
+	return v.ErrorOrNil()
+}
+
+// TODO: update title once a day or something?
+func (p *Path) GetOrInsert(ctx context.Context) error {
+	db := zdb.MustGet(ctx)
+	site := MustGetSite(ctx)
+
+	p.Defaults(ctx)
+	err := p.Validate(ctx)
+	if err != nil {
+		return err
+	}
+
+	row := db.QueryRowxContext(ctx, `/* Path.GetOrInsert */
+		select * from paths
+		where site=$1 and lower(path)=lower($2)
+		limit 1`,
+		site.ID, p.Path)
+	if row.Err() != nil {
+		return errors.Errorf("Path.GetOrInsert select: %w", row.Err())
+	}
+	err = row.StructScan(p)
+	if err != nil && !zdb.ErrNoRows(err) {
+		return errors.Errorf("Path.GetOrInsert select: %w", err)
+	}
+	if err == nil {
+		return nil
+	}
+
+	// Insert new row.
+	query := `insert into paths (site, path, title) values ($1, $2, $3)`
+	args := []interface{}{site.ID, p.Path, p.Title}
+	if cfg.PgSQL {
+		err = db.GetContext(ctx, &p.ID, query+" returning id", args...)
+		return errors.Wrap(err, "Path.GetOrInsert insert")
+	}
+
+	r, err := db.ExecContext(ctx, query, args...)
+	if err != nil {
+		return errors.Errorf("Path.GetOrInsert insert: %w", err)
+	}
+	p.ID, err = r.LastInsertId()
+	if err != nil {
+		return errors.Errorf("Path.GetOrInsert insert: %w", err)
+	}
+
+	return nil
+}

--- a/user_agent.go
+++ b/user_agent.go
@@ -1,0 +1,98 @@
+// Copyright © 2019 Martin Tournoij <martin@arp242.net>
+// This file is part of GoatCounter and published under the terms of the EUPL
+// v1.2, which can be found in the LICENSE file or at http://eupl12.zgo.at
+
+package goatcounter
+
+import (
+	"context"
+
+	"zgo.at/errors"
+	"zgo.at/gadget"
+	"zgo.at/goatcounter/cfg"
+	"zgo.at/zdb"
+	"zgo.at/zvalidate"
+)
+
+type UserAgent struct {
+	ID        int64  `db:"user_agent_id"`
+	UserAgent string `db:"ua"`
+
+	Bot            uint8  `db:"bot"`
+	Browser        string `db:"browser"`
+	BrowserVersion string `db:"browser_version"`
+	System         string `db:"system"`
+	SystemVersion  string `db:"system_version"`
+}
+
+func (p *UserAgent) Defaults(ctx context.Context) {
+	ua := gadget.Parse(p.UserAgent)
+	p.Browser, p.BrowserVersion = ua.BrowserName, ua.BrowserVersion
+	p.System, p.SystemVersion = ua.OSName, ua.OSVersion
+}
+
+func (p *UserAgent) Validate(ctx context.Context) error {
+	v := zvalidate.New()
+
+	v.UTF8("browser", p.UserAgent)
+	v.Len("browser", p.Browser, 0, 512)
+
+	// v.Required("browser", p.Browser)
+	// v.Required("browser_version", p.BrowserVersion)
+	// v.Required("system", p.System)
+	// v.Required("system_version", p.SystemVersion)
+
+	return v.ErrorOrNil()
+}
+
+func (p *UserAgent) GetOrInsert(ctx context.Context) error {
+	db := zdb.MustGet(ctx)
+
+	p.Defaults(ctx)
+	err := p.Validate(ctx)
+	if err != nil {
+		return err
+	}
+
+	row := db.QueryRowxContext(ctx, `/* Path.GetOrInsert */
+		select * from user_agents
+		where ua = $1
+		limit 1`,
+		p.UserAgent)
+	if row.Err() != nil {
+		return errors.Errorf("UserAgent.GetOrInsert select: %w", row.Err())
+	}
+
+	err = row.StructScan(p)
+	if err != nil && !zdb.ErrNoRows(err) {
+		return errors.Errorf("UserAgent.GetOrInsert select: %w", err)
+	}
+	if err == nil {
+		return nil
+	}
+
+	// Insert new row.
+	// TODO: shorten
+	// TODO: isbot := isbot.Bot(r)
+
+	query := `insert into user_agents
+		(ua, bot, browser, browser_version, system, system_version) values
+		($1, $2, $3, $4, $5, $6)`
+	args := []interface{}{p.UserAgent, 0, p.Browser, p.BrowserVersion, p.System, p.SystemVersion}
+
+	if cfg.PgSQL {
+		err = db.GetContext(ctx, &p.ID, query+" returning id", args...)
+		return errors.Wrap(err, "UserAgent.GetOrInsert insert")
+	}
+
+	r, err := db.ExecContext(ctx, query, args...)
+	if err != nil {
+		return errors.Errorf("UserAgent.GetOrInsert insert: %w", err)
+	}
+	p.ID, err = r.LastInsertId()
+	if err != nil {
+		return errors.Errorf("UserAgent.GetOrInsert insert: %w", err)
+	}
+
+	return nil
+}


### PR DESCRIPTION
This changes how the paths and user_agents are stored: instead of
duplicating it for every single pageview, store it in their own table.
This saves quite a bit of space and improves query performance across
the board.

The database migration for this is a bit of a beast, and may take a
while if you have many (millions) of pageviews.
