### PR TITLE
Support TOTP multi-factor authentication

### DIFF
--- a/db/migrate/pgsql/2020-06-18-1-totp.sql
+++ b/db/migrate/pgsql/2020-06-18-1-totp.sql
@@ -1,7 +1,21 @@
 begin;
 	alter table users
 		add column totp_enabled integer not null default 0,
-		add column totp_secret bytea not null;
+		add column totp_secret bytea;
+
+	-- https://dba.stackexchange.com/a/22571/2629
+	CREATE OR REPLACE FUNCTION random_bytea(bytea_length integer)
+	RETURNS bytea AS $body$
+		SELECT decode(string_agg(lpad(to_hex(width_bucket(random(), 0, 1, 256)-1),2,'0') ,''), 'hex')
+		FROM generate_series(1, $1);
+	$body$
+	LANGUAGE 'sql'
+	VOLATILE
+	SET search_path = 'pg_catalog';
+
+	update users set totp_secret=random_bytea(16);
+
+	drop function random_bytea;
 
 	insert into version values('2020-06-18-1-totp');
 commit;

--- a/db/migrate/pgsql/2020-06-18-1-totp.sql
+++ b/db/migrate/pgsql/2020-06-18-1-totp.sql
@@ -1,0 +1,7 @@
+begin;
+	alter table users
+		add column totp_enabled integer not null default 0,
+		add column totp_secret bytea not null;
+
+	insert into version values('2020-06-18-1-totp');
+commit;

--- a/db/migrate/sqlite/2020-06-18-1-totp.sql
+++ b/db/migrate/sqlite/2020-06-18-1-totp.sql
@@ -1,5 +1,8 @@
 begin;
 	alter table users add column totp_enabled integer not null default 0;
-	alter table users add column totp_secret blob not null;
+	alter table users add column totp_secret blob;
+
+	update users set totp_secret=randomblob(16);
+
 	insert into version values('2020-06-18-1-totp');
 commit;

--- a/db/migrate/sqlite/2020-06-18-1-totp.sql
+++ b/db/migrate/sqlite/2020-06-18-1-totp.sql
@@ -1,0 +1,5 @@
+begin;
+	alter table users add column totp_enabled integer not null default 0;
+	alter table users add column totp_secret blob not null;
+	insert into version values('2020-06-18-1-totp');
+commit;

--- a/go.mod
+++ b/go.mod
@@ -3,8 +3,10 @@ module zgo.at/goatcounter
 go 1.13
 
 require (
+	code.soquee.net/otp v0.0.1
 	github.com/PuerkitoBio/goquery v1.5.1
 	github.com/arp242/geoip2-golang v1.4.0
+	github.com/boombuler/barcode v1.0.0
 	github.com/go-chi/chi v4.1.2+incompatible
 	github.com/jmoiron/sqlx v1.2.0
 	github.com/lib/pq v1.5.2
@@ -12,6 +14,7 @@ require (
 	github.com/monoculum/formam v0.0.0-20200527175922-6f3cce7a46cf
 	github.com/teamwork/reload v1.3.2
 	golang.org/x/crypto v0.0.0-20200510223506-06a226fb4e37
+	golang.org/x/net v0.0.0-20200324143707-d3edc9973b7e
 	golang.org/x/sync v0.0.0-20200317015054-43a5402ce75a
 	golang.org/x/tools v0.0.0-20200519205726-57a9e4404bf7
 	honnef.co/go/tools v0.0.1-2020.1.4

--- a/go.sum
+++ b/go.sum
@@ -1,3 +1,5 @@
+code.soquee.net/otp v0.0.1 h1:sPALeimyp/DAj4MXMjj94QDdYN/y2+dSoMXQCxttpvw=
+code.soquee.net/otp v0.0.1/go.mod h1:sv1t9zLujoOZ8T14ty2ffdj6y+fjScwX7m76G+dzrm0=
 github.com/BurntSushi/toml v0.3.1 h1:WXkYYl6Yr3qBf1K79EBnL4mak0OimBfB0XUf9Vl28OQ=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
 github.com/PuerkitoBio/goquery v1.5.1 h1:PSPBGne8NIUWw+/7vFBV+kG2J/5MOjbzc7154OaKCSE=
@@ -8,6 +10,8 @@ github.com/arp242/geoip2-golang v1.4.0 h1:oABeHO8xeXWqtuRF3Uq09cGlWrHIGLXkTUK55a
 github.com/arp242/geoip2-golang v1.4.0/go.mod h1:AZYwUhu7pAKqHkiZTQhSCWaexFJDwzR3K9jIrhkNDko=
 github.com/arp242/maxminddb-golang v1.6.0 h1:7IAwS+vjRSJpCFwBt9Co6mz/EWZPEA+JBt4XfKv28Uc=
 github.com/arp242/maxminddb-golang v1.6.0/go.mod h1:zZGWhFkxTFX80NKfpEHn6vqd50ksDYTBP8Zi+Xk10OI=
+github.com/boombuler/barcode v1.0.0 h1:s1TvRnXwL2xJRaccrdcBQMZxq6X7DvsMogtmJeHDdrc=
+github.com/boombuler/barcode v1.0.0/go.mod h1:paBWMcWSl3LHKBqUq+rly7CNSldXjb2rDl3JlRe0mD8=
 github.com/fsnotify/fsnotify v1.4.9 h1:hsms1Qyu0jgnwNXIxa+/V/PDsU6CfLf6CNO8H7IWoS4=
 github.com/fsnotify/fsnotify v1.4.9/go.mod h1:znqG4EE+3YCdAaPaxE2ZRY/06pZUdp0tY4IgpuI1SZQ=
 github.com/go-chi/chi v4.1.2+incompatible h1:fGFk2Gmi/YKXk0OmGfBh0WgmN3XB8lVnEyNz34tQRec=

--- a/handlers/user.go
+++ b/handlers/user.go
@@ -30,7 +30,10 @@ import (
 	"zgo.at/zvalidate"
 )
 
-const actionTOTP = "totp"
+const (
+	actionTOTP = "totp"
+	mfaError   = "Token did not match; perhaps you waited too long? Try again."
+)
 
 type user struct{}
 
@@ -182,7 +185,7 @@ func (h user) totpLogin(w http.ResponseWriter, r *http.Request) error {
 	if strconv.Itoa(int(tokGen(0, nil))) != args.Token &&
 		strconv.Itoa(int(tokGen(-1, nil))) != args.Token &&
 		strconv.Itoa(int(tokGen(1, nil))) != args.Token {
-		zhttp.FlashError(w, "Token did not match.")
+		zhttp.FlashError(w, mfaError)
 		return zhttp.Template(w, "totp.gohtml", struct {
 			Globals
 			LoginMAC string
@@ -331,7 +334,7 @@ func (h user) disableTOTP(w http.ResponseWriter, r *http.Request) error {
 		return err
 	}
 
-	return zhttp.SeeOther(w, "/settings#tab-mfa-settings")
+	return zhttp.SeeOther(w, "/settings#tab-auth")
 }
 
 func (h user) enableTOTP(w http.ResponseWriter, r *http.Request) error {
@@ -352,15 +355,15 @@ func (h user) enableTOTP(w http.ResponseWriter, r *http.Request) error {
 	if strconv.Itoa(int(tokGen(0, nil))) != args.Token &&
 		strconv.Itoa(int(tokGen(-1, nil))) != args.Token &&
 		strconv.Itoa(int(tokGen(1, nil))) != args.Token {
-		zhttp.FlashError(w, "Token did not match.")
-		return zhttp.SeeOther(w, "/settings#tab-mfa-settings")
+		zhttp.FlashError(w, mfaError)
+		return zhttp.SeeOther(w, "/settings#tab-auth")
 	}
 
 	err = u.EnableTOTP(r.Context())
 	if err != nil {
 		return err
 	}
-	return zhttp.SeeOther(w, "/settings#tab-mfa-settings")
+	return zhttp.SeeOther(w, "/settings#tab-auth")
 }
 
 func (h user) changePassword(w http.ResponseWriter, r *http.Request) error {

--- a/handlers/user.go
+++ b/handlers/user.go
@@ -5,15 +5,20 @@
 package handlers
 
 import (
+	"crypto/sha1"
 	"errors"
 	"fmt"
 	"net/http"
 	"net/mail"
 	"net/url"
+	"strconv"
 	"strings"
+	"time"
 
+	"code.soquee.net/otp"
 	"github.com/go-chi/chi"
 	"golang.org/x/crypto/bcrypt"
+	"golang.org/x/net/xsrftoken"
 	"zgo.at/blackmail"
 	"zgo.at/goatcounter"
 	"zgo.at/goatcounter/bgrun"
@@ -24,6 +29,8 @@ import (
 	"zgo.at/zlog"
 	"zgo.at/zvalidate"
 )
+
+const actionTOTP = "totp"
 
 type user struct{}
 
@@ -39,6 +46,7 @@ func (h user) mount(r chi.Router) {
 		Limit:  zhttp.RatelimitLimit(20, 60),
 	}))
 	rate.Post("/user/requestlogin", zhttp.Wrap(h.requestLogin))
+	rate.Post("/user/totplogin", zhttp.Wrap(h.totpLogin))
 	rate.Get("/user/reset/{key}", zhttp.Wrap(h.reset))
 	rate.Get("/user/verify/{key}", zhttp.Wrap(h.verify))
 	rate.Post("/user/reset/{key}", zhttp.Wrap(h.doReset))
@@ -46,6 +54,8 @@ func (h user) mount(r chi.Router) {
 	auth := r.With(loggedIn)
 	auth.Post("/user/logout", zhttp.Wrap(h.logout))
 	auth.Post("/user/change-password", zhttp.Wrap(h.changePassword))
+	auth.Post("/user/disable-totp", zhttp.Wrap(h.disableTOTP))
+	auth.Post("/user/enable-totp", zhttp.Wrap(h.enableTOTP))
 	auth.Post("/user/resend-verify", zhttp.Wrap(h.resendVerify))
 }
 
@@ -140,6 +150,49 @@ func (h user) requestReset(w http.ResponseWriter, r *http.Request) error {
 	return zhttp.SeeOther(w, "/user/forgot")
 }
 
+func (h user) totpLogin(w http.ResponseWriter, r *http.Request) error {
+	args := struct {
+		LoginMAC string `json:"loginmac"`
+		Token    string `json:"totp_token"`
+	}{}
+	_, err := zhttp.Decode(r, &args)
+	if err != nil {
+		return err
+	}
+
+	site := goatcounter.MustGetSite(r.Context())
+
+	var u goatcounter.User
+	err = u.BySite(r.Context(), site.IDOrParent())
+	if err != nil {
+		return err
+	}
+
+	valid := xsrftoken.Valid(args.LoginMAC, *u.LoginToken, strconv.FormatInt(u.ID, 10), actionTOTP)
+	if !valid {
+		zhttp.Flash(w, "Invalid login")
+		return zhttp.SeeOther(w, "/")
+	}
+
+	tokGen := otp.NewOTP(u.TOTPSecret, 6, sha1.New, otp.TOTP(30*time.Second, time.Now))
+
+	// Check a 30 second window on either side of the current time as well. It's
+	// common for clocks to be slightly out of sync and this prevents most errors
+	// and is what the spec recommends.
+	if strconv.Itoa(int(tokGen(0, nil))) != args.Token &&
+		strconv.Itoa(int(tokGen(-1, nil))) != args.Token &&
+		strconv.Itoa(int(tokGen(1, nil))) != args.Token {
+		zhttp.FlashError(w, "Token did not match.")
+		return zhttp.Template(w, "totp.gohtml", struct {
+			Globals
+			LoginMAC string
+		}{newGlobals(w, r), args.LoginMAC})
+	}
+
+	zhttp.SetCookie(w, *u.LoginToken, site.Domain())
+	return zhttp.SeeOther(w, "/")
+}
+
 func (h user) requestLogin(w http.ResponseWriter, r *http.Request) error {
 	u := goatcounter.GetUser(r.Context())
 	if u != nil && u.ID > 0 {
@@ -189,6 +242,13 @@ func (h user) requestLogin(w http.ResponseWriter, r *http.Request) error {
 	err = user.Login(r.Context())
 	if err != nil {
 		return err
+	}
+
+	if user.TOTPEnabled {
+		return zhttp.Template(w, "totp.gohtml", struct {
+			Globals
+			LoginMAC string
+		}{newGlobals(w, r), xsrftoken.Generate(*user.LoginToken, strconv.FormatInt(user.ID, 10), actionTOTP)})
 	}
 
 	zhttp.SetCookie(w, *user.LoginToken, site.Domain())
@@ -262,6 +322,45 @@ func (h user) logout(w http.ResponseWriter, r *http.Request) error {
 
 	zhttp.ClearCookie(w, goatcounter.MustGetSite(r.Context()).Domain())
 	return zhttp.SeeOther(w, "/")
+}
+
+func (h user) disableTOTP(w http.ResponseWriter, r *http.Request) error {
+	u := goatcounter.GetUser(r.Context())
+	err := u.DisableTOTP(r.Context())
+	if err != nil {
+		return err
+	}
+
+	return zhttp.SeeOther(w, "/settings#tab-mfa-settings")
+}
+
+func (h user) enableTOTP(w http.ResponseWriter, r *http.Request) error {
+	u := goatcounter.GetUser(r.Context())
+	var args struct {
+		Token string `json:"totp_token"`
+	}
+	_, err := zhttp.Decode(r, &args)
+	if err != nil {
+		return err
+	}
+
+	tokGen := otp.NewOTP(u.TOTPSecret, 6, sha1.New, otp.TOTP(30*time.Second, time.Now))
+
+	// Check a 30 second window on either side of the current time as well. It's
+	// common for clocks to be slightly out of sync and this prevents most errors
+	// and is what the spec recommends.
+	if strconv.Itoa(int(tokGen(0, nil))) != args.Token &&
+		strconv.Itoa(int(tokGen(-1, nil))) != args.Token &&
+		strconv.Itoa(int(tokGen(1, nil))) != args.Token {
+		zhttp.FlashError(w, "Token did not match.")
+		return zhttp.SeeOther(w, "/settings#tab-mfa-settings")
+	}
+
+	err = u.EnableTOTP(r.Context())
+	if err != nil {
+		return err
+	}
+	return zhttp.SeeOther(w, "/settings#tab-mfa-settings")
 }
 
 func (h user) changePassword(w http.ResponseWriter, r *http.Request) error {

--- a/handlers/user.go
+++ b/handlers/user.go
@@ -178,13 +178,17 @@ func (h user) totpLogin(w http.ResponseWriter, r *http.Request) error {
 	}
 
 	tokGen := otp.NewOTP(u.TOTPSecret, 6, sha1.New, otp.TOTP(30*time.Second, time.Now))
+	tokInt, err := strconv.ParseInt(args.Token, 10, 32)
+	if err != nil {
+		return err
+	}
 
 	// Check a 30 second window on either side of the current time as well. It's
 	// common for clocks to be slightly out of sync and this prevents most errors
 	// and is what the spec recommends.
-	if strconv.Itoa(int(tokGen(0, nil))) != args.Token &&
-		strconv.Itoa(int(tokGen(-1, nil))) != args.Token &&
-		strconv.Itoa(int(tokGen(1, nil))) != args.Token {
+	if tokGen(0, nil) != int32(tokInt) &&
+		tokGen(-1, nil) != int32(tokInt) &&
+		tokGen(1, nil) != int32(tokInt) {
 		zhttp.FlashError(w, mfaError)
 		return zhttp.Template(w, "totp.gohtml", struct {
 			Globals
@@ -348,13 +352,17 @@ func (h user) enableTOTP(w http.ResponseWriter, r *http.Request) error {
 	}
 
 	tokGen := otp.NewOTP(u.TOTPSecret, 6, sha1.New, otp.TOTP(30*time.Second, time.Now))
+	tokInt, err := strconv.ParseInt(args.Token, 10, 32)
+	if err != nil {
+		return err
+	}
 
 	// Check a 30 second window on either side of the current time as well. It's
 	// common for clocks to be slightly out of sync and this prevents most errors
 	// and is what the spec recommends.
-	if strconv.Itoa(int(tokGen(0, nil))) != args.Token &&
-		strconv.Itoa(int(tokGen(-1, nil))) != args.Token &&
-		strconv.Itoa(int(tokGen(1, nil))) != args.Token {
+	if tokGen(0, nil) != int32(tokInt) &&
+		tokGen(-1, nil) != int32(tokInt) &&
+		tokGen(1, nil) != int32(tokInt) {
 		zhttp.FlashError(w, mfaError)
 		return zhttp.SeeOther(w, "/settings#tab-auth")
 	}

--- a/pack/pack.go
+++ b/pack/pack.go
@@ -592,7 +592,21 @@ commit;
 	"db/migrate/pgsql/2020-06-18-1-totp.sql": []byte(`begin;
 	alter table users
 		add column totp_enabled integer not null default 0,
-		add column totp_secret bytea not null;
+		add column totp_secret bytea;
+
+	-- https://dba.stackexchange.com/a/22571/2629
+	CREATE OR REPLACE FUNCTION random_bytea(bytea_length integer)
+	RETURNS bytea AS $body$
+		SELECT decode(string_agg(lpad(to_hex(width_bucket(random(), 0, 1, 256)-1),2,'0') ,''), 'hex')
+		FROM generate_series(1, $1);
+	$body$
+	LANGUAGE 'sql'
+	VOLATILE
+	SET search_path = 'pg_catalog';
+
+	update users set totp_secret=random_bytea(16);
+
+	drop function random_bytea;
 
 	insert into version values('2020-06-18-1-totp');
 commit;
@@ -1382,7 +1396,10 @@ commit;
 `),
 	"db/migrate/sqlite/2020-06-18-1-totp.sql": []byte(`begin;
 	alter table users add column totp_enabled integer not null default 0;
-	alter table users add column totp_secret blob not null;
+	alter table users add column totp_secret blob;
+
+	update users set totp_secret=randomblob(16);
+
 	insert into version values('2020-06-18-1-totp');
 commit;
 `),

--- a/pack/pack.go
+++ b/pack/pack.go
@@ -16697,9 +16697,10 @@ input    { float: right; padding: .4em !important; }
 	<div class="flex-form">
 
 	<form method="post" action="/user/change-password" class="vertical">
+		<input type="hidden" name="csrf" value="{{.User.CSRFToken}}">
+
 		<fieldset>
 			<legend>Change password</legend>
-			<input type="hidden" name="csrf" value="{{.User.CSRFToken}}">
 
 			{{if .User.Password}}
 				<label for="c_password">Current password</label>
@@ -16721,27 +16722,29 @@ input    { float: right; padding: .4em !important; }
 
 	{{if .User.TOTPEnabled}}
 		<form method="post" action="/user/disable-totp" class="vertical">
+			<input type="hidden" name="csrf" value="{{.User.CSRFToken}}">
+
 			<fieldset>
 				<legend>Multi-factor authentication</legend>
 
 				<p>MFA is currently enabled for this account.</p>
 
-				<input type="hidden" name="csrf" value="{{.User.CSRFToken}}">
 				<button type="submit">Disable MFA</button>
 			</fieldset>
 		</form>
 	{{else}}
 		<form method="post" action="/user/enable-totp" class="vertical">
+			<input type="hidden" name="csrf" value="{{.User.CSRFToken}}">
+
 			<fieldset>
 				<legend>Multi-factor authentication</legend>
 				<p>Enable TOTP-based multi-factor authentication by scanning the
 				code in your authenticator app or entering the secret.</p>
 
-				<input type="hidden" name="csrf" value="{{.User.CSRFToken}}">
-				<img alt="TOTP Secret Barcode" title="TOTP Secret Barcode"
-					src="{{ totpbarcode .User.Email (base32 .User.TOTPSecret) }}"><br>
+				{{totp_barcode .User.Email (base32 .User.TOTPSecret) }}
 				<label for="secret_text">Secret:</label>
 				<div id="secret_text">{{ .User.TOTPSecret | base32 }}</div>
+
 				<label for="totp_token">Verification token</label>
 				<input type="text" name="totp_token" id="totp_token" required
 					autocomplete="one-time-code"><br>

--- a/public/style_backend.css
+++ b/public/style_backend.css
@@ -59,6 +59,10 @@ form .err  { color: red; display: block; }
 @media (min-width: 55rem) {
 	.form-wrap form          { display: flex; flex-wrap: wrap; }
 	.form-wrap form fieldset { width: 48%; }
+
+	.flex-form          { display: flex; flex-wrap: wrap; }
+	.flex-form form     { width: 48%; }
+	.flex-form fieldset { height: 100%; }
 }
 
 .flash {

--- a/tpl/_backend_totp.gohtml
+++ b/tpl/_backend_totp.gohtml
@@ -1,8 +1,0 @@
-<form method="post" action="/user/totplogin" class="vertical">
-	<input type="hidden" id="loginmac" name="loginmac" value="{{ .LoginMAC }}">
-	<label for="totp_token">MFA Token</label>
-	<input type="text" name="totp_token" id="totp_token"
-		inputmode="numeric" pattern="[0-9]*"
-		required autocomplete="one-time-code"><br>
-	<button>Sign in</button>
-</form>

--- a/tpl/_backend_totp.gohtml
+++ b/tpl/_backend_totp.gohtml
@@ -1,0 +1,8 @@
+<form method="post" action="/user/totplogin" class="vertical">
+	<input type="hidden" id="loginmac" name="loginmac" value="{{ .LoginMAC }}">
+	<label for="totp_token">MFA Token</label>
+	<input type="text" name="totp_token" id="totp_token"
+		inputmode="numeric" pattern="[0-9]*"
+		required autocomplete="one-time-code"><br>
+	<button>Sign in</button>
+</form>

--- a/tpl/backend_settings.gohtml
+++ b/tpl/backend_settings.gohtml
@@ -262,9 +262,10 @@
 	<div class="flex-form">
 
 	<form method="post" action="/user/change-password" class="vertical">
+		<input type="hidden" name="csrf" value="{{.User.CSRFToken}}">
+
 		<fieldset>
 			<legend>Change password</legend>
-			<input type="hidden" name="csrf" value="{{.User.CSRFToken}}">
 
 			{{if .User.Password}}
 				<label for="c_password">Current password</label>
@@ -286,27 +287,29 @@
 
 	{{if .User.TOTPEnabled}}
 		<form method="post" action="/user/disable-totp" class="vertical">
+			<input type="hidden" name="csrf" value="{{.User.CSRFToken}}">
+
 			<fieldset>
 				<legend>Multi-factor authentication</legend>
 
 				<p>MFA is currently enabled for this account.</p>
 
-				<input type="hidden" name="csrf" value="{{.User.CSRFToken}}">
 				<button type="submit">Disable MFA</button>
 			</fieldset>
 		</form>
 	{{else}}
 		<form method="post" action="/user/enable-totp" class="vertical">
+			<input type="hidden" name="csrf" value="{{.User.CSRFToken}}">
+
 			<fieldset>
 				<legend>Multi-factor authentication</legend>
 				<p>Enable TOTP-based multi-factor authentication by scanning the
 				code in your authenticator app or entering the secret.</p>
 
-				<input type="hidden" name="csrf" value="{{.User.CSRFToken}}">
-				<img alt="TOTP Secret Barcode" title="TOTP Secret Barcode"
-					src="{{ totpbarcode .User.Email (base32 .User.TOTPSecret) }}"><br>
+				{{totp_barcode .User.Email (base32 .User.TOTPSecret) }}
 				<label for="secret_text">Secret:</label>
 				<div id="secret_text">{{ .User.TOTPSecret | base32 }}</div>
+
 				<label for="totp_token">Verification token</label>
 				<input type="text" name="totp_token" id="totp_token" required
 					autocomplete="one-time-code"><br>

--- a/tpl/backend_settings.gohtml
+++ b/tpl/backend_settings.gohtml
@@ -281,6 +281,31 @@
 	</form>
 </div>
 
+<div>
+	<h2 id="mfa-settings">MFA Settings</h2>
+
+	{{ if .User.TOTPEnabled }}
+	<form method="post" action="/user/disable-totp" class="form-max-width vertical">
+		<input type="hidden" name="csrf" value="{{.User.CSRFToken}}">
+		<button type="submit">Disable TOTP</button>
+	</form>
+	{{ else }}
+	<form method="post" action="/user/enable-totp" class="form-max-width vertical">
+		<input type="hidden" name="csrf" value="{{.User.CSRFToken}}">
+		<img alt="TOTP Secret Barcode" title="TOTP Secret Barcode"
+			src="{{ totpbarcode .User.Email (base32 .User.TOTPSecret) }}"/><br>
+		<label for="secret_text">Secret:</label>
+		<div id="secret_text">{{ .User.TOTPSecret | base32 }}</div>
+		<label for="totp_token">TOTP Token</label>
+		<input type="text" name="totp_token" id="totp_token" required
+			autocomplete="one-time-code"><br>
+
+
+		<button type="submit">Enable TOTP</button>
+	</form>
+	{{ end }}
+</div>
+
 {{if .GoatcounterCom}}
 	<div>
 		<h2 id="delete">Delete {{if .Site.Parent}}site{{else}}account{{end}}</h2>

--- a/tpl/backend_settings.gohtml
+++ b/tpl/backend_settings.gohtml
@@ -312,7 +312,7 @@
 
 				<label for="totp_token">Verification token</label>
 				<input type="text" name="totp_token" id="totp_token" required
-					autocomplete="one-time-code"><br>
+					autocomplete="one-time-code" inputmode="numeric" pattern="[0-9]*"><br>
 
 				<button type="submit">Enable MFA</button>
 			</fieldset>

--- a/tpl/backend_settings.gohtml
+++ b/tpl/backend_settings.gohtml
@@ -258,52 +258,64 @@
 </div>
 
 <div>
-	<h2 id="change-password">Change password</h2>
+	<h2 id="auth">Password &amp; MFA</h2>
+	<div class="flex-form">
 
-	<form method="post" action="/user/change-password" class="form-max-width vertical">
-		<input type="hidden" name="csrf" value="{{.User.CSRFToken}}">
+	<form method="post" action="/user/change-password" class="vertical">
+		<fieldset>
+			<legend>Change password</legend>
+			<input type="hidden" name="csrf" value="{{.User.CSRFToken}}">
 
-		{{if .User.Password}}
-			<label for="c_password">Current password</label>
-			<input type="password" name="c_password" id="c_password" required
-				autocomplete="current-password"><br>
-		{{end}}
+			{{if .User.Password}}
+				<label for="c_password">Current password</label>
+				<input type="password" name="c_password" id="c_password" required
+					autocomplete="current-password"><br>
+			{{end}}
 
-		<label for="password">New password</label>
-		<input type="password" name="password" id="password" required
-			autocomplete="new-password"><br>
+			<label for="password">New password</label>
+			<input type="password" name="password" id="password" required
+				autocomplete="new-password"><br>
 
-		<label for="password2">New password (confirm)</label>
-		<input type="password" name="password2" id="password2" required
-			autocomplete="new-password"><br>
+			<label for="password2">New password (confirm)</label>
+			<input type="password" name="password2" id="password2" required
+				autocomplete="new-password"><br>
 
-		<button>Change password</button>
+			<button>Change password</button>
+		</fieldset>
 	</form>
+
+	{{if .User.TOTPEnabled}}
+		<form method="post" action="/user/disable-totp" class="vertical">
+			<fieldset>
+				<legend>Multi-factor authentication</legend>
+
+				<p>MFA is currently enabled for this account.</p>
+
+				<input type="hidden" name="csrf" value="{{.User.CSRFToken}}">
+				<button type="submit">Disable MFA</button>
+			</fieldset>
+		</form>
+	{{else}}
+		<form method="post" action="/user/enable-totp" class="vertical">
+			<fieldset>
+				<legend>Multi-factor authentication</legend>
+				<p>Enable TOTP-based multi-factor authentication by scanning the
+				code in your authenticator app or entering the secret.</p>
+
+				<input type="hidden" name="csrf" value="{{.User.CSRFToken}}">
+				<img alt="TOTP Secret Barcode" title="TOTP Secret Barcode"
+					src="{{ totpbarcode .User.Email (base32 .User.TOTPSecret) }}"><br>
+				<label for="secret_text">Secret:</label>
+				<div id="secret_text">{{ .User.TOTPSecret | base32 }}</div>
+				<label for="totp_token">Verification token</label>
+				<input type="text" name="totp_token" id="totp_token" required
+					autocomplete="one-time-code"><br>
+
+				<button type="submit">Enable MFA</button>
+			</fieldset>
+		</form>
+	{{end}}
 </div>
-
-<div>
-	<h2 id="mfa-settings">MFA Settings</h2>
-
-	{{ if .User.TOTPEnabled }}
-	<form method="post" action="/user/disable-totp" class="form-max-width vertical">
-		<input type="hidden" name="csrf" value="{{.User.CSRFToken}}">
-		<button type="submit">Disable TOTP</button>
-	</form>
-	{{ else }}
-	<form method="post" action="/user/enable-totp" class="form-max-width vertical">
-		<input type="hidden" name="csrf" value="{{.User.CSRFToken}}">
-		<img alt="TOTP Secret Barcode" title="TOTP Secret Barcode"
-			src="{{ totpbarcode .User.Email (base32 .User.TOTPSecret) }}"/><br>
-		<label for="secret_text">Secret:</label>
-		<div id="secret_text">{{ .User.TOTPSecret | base32 }}</div>
-		<label for="totp_token">TOTP Token</label>
-		<input type="text" name="totp_token" id="totp_token" required
-			autocomplete="one-time-code"><br>
-
-
-		<button type="submit">Enable TOTP</button>
-	</form>
-	{{ end }}
 </div>
 
 {{if .GoatcounterCom}}

--- a/tpl/totp.gohtml
+++ b/tpl/totp.gohtml
@@ -1,0 +1,6 @@
+{{template "_backend_top.gohtml" .}}
+
+<h1>Multi-factor auth</h1>
+{{template "_backend_totp.gohtml" .}}
+
+{{template "_backend_bottom.gohtml" .}}

--- a/tpl/totp.gohtml
+++ b/tpl/totp.gohtml
@@ -1,6 +1,16 @@
 {{template "_backend_top.gohtml" .}}
 
 <h1>Multi-factor auth</h1>
-{{template "_backend_totp.gohtml" .}}
+<p>This account is protected with multi-factor auth; please enter the code from
+your authenticator app.</p>
+
+<form method="post" action="/user/totplogin" class="vertical">
+	<input type="hidden" id="loginmac" name="loginmac" value="{{ .LoginMAC }}">
+	<label for="totp_token">MFA Token</label>
+	<input type="text" name="totp_token" id="totp_token"
+		inputmode="numeric" pattern="[0-9]*"
+		required autocomplete="one-time-code"><br>
+	<button>Sign in</button>
+</form>
 
 {{template "_backend_bottom.gohtml" .}}

--- a/user.go
+++ b/user.go
@@ -296,7 +296,7 @@ func (u *User) RequestReset(ctx context.Context) error {
 
 func (u *User) EnableTOTP(ctx context.Context) error {
 	_, err := zdb.MustGet(ctx).ExecContext(ctx, `update users set totp_enabled=1
-		where id=$2 and site=$3`,
+		where id=$1 and site=$2`,
 		u.ID, MustGetSite(ctx).IDOrParent())
 	if err != nil {
 		return errors.Wrap(err, "User.EnableTOTP")


### PR DESCRIPTION
This supports multi-factor authentication using the Time-Based One-Time
Password Algorithm (TOTP) defined in [RFC 6238].
It uses the default parameters for all token fields because changing
these parameters is not supported by the vast majority of web
applications, and by some authenticator applications.

After the initial password authentication, the TOTP page is rendered
instead of issuing a login cookie if the user has enabled TOTP in their
settings.
The TOTP page verifies that the username and password were entered
correctly by validating an HMAC generated using the users session
secret, user ID, and an expiration time.
If the token is valid, a real login cookie is issued by the TOTP handler
just as it would have been by the requestlogin handler if TOTP had been
disabled.

The term "multi-factor authentication" is used instead of "two-factor
authentication" in case other methods or more complex login flows are
used in the future (where there might be more than two factors).

Fixes #235

[RFC 6238]: https://tools.ietf.org/html/rfc6238