### PR TITLE
Fix text flowing through the trial-expired banner

### DIFF
--- a/public/style_backend.css
+++ b/public/style_backend.css
@@ -26,7 +26,7 @@ footer a { font-weight: bold; color: #252525; margin: 0 .5em; }
 .form-max-width label { display: inline-block; }
 
 #trial-expired { position: fixed; bottom: 0; left: 0; right: 0; text-align: center;
-                 background-color: #fff0f0; border-top: 1px solid #f00; }
+                 background-color: #fff0f0; border-top: 1px solid #f00; z-index: 1; }
 
 #js-settings, #js-csrf { display: none; }
 


### PR DESCRIPTION
The stats text flows through the trial-expired banner:
![image](https://user-images.githubusercontent.com/1049485/86963271-888c2e00-c164-11ea-8431-10fa58a08ec7.png)

This pull request fixes this by adding a z-index. 
