### PR TITLE
Set Cache-Control headers for static files in goatcounter serve

### DIFF
--- a/CHANGELOG.markdown
+++ b/CHANGELOG.markdown
@@ -15,6 +15,13 @@ master branch
   which is probably a better and less confusing default for most people. There
   is also some more detailed docs available in `goatcounter help listen`.
 
+- Set Cache-Control header for static files (#348
+
+  The `Cache-Control` header is now set for static files. Since the "cache
+  busting" happens based on the goatcounter version it's now recommended to set
+  this if you're compiling GoatCounter yourself. See the updated README for
+  instructions.
+
 - Add multi-factor auth (#306)
 
   TOTP-based multi-factor auth is now supported.

--- a/README.markdown
+++ b/README.markdown
@@ -98,11 +98,17 @@ Compile from source with:
 
     $ git clone -b release-1.3 https://github.com/zgoat/goatcounter.git
     $ cd goatcounter
-    $ go build ./cmd/goatcounter
+    $ go build -ldflags="-X main.version=$(git log -n1 --format='%h_%cI')" ./cmd/goatcounter
+
+The `-ldflags=[..]` sets the version; this isn't *strictly* required as such,
+but it's recommended as it's used to "bust" the cache for static files and may
+also be useful later when reporting bugs. This can be any string and doesn't
+follow any particular format, you can also set this to the current date or
+`banana` or anything you want really.
 
 Or to build a statically linked binary:
 
-    $ go build \
+    $ go build -ldflags="-X main.version=$(git log -n1 --format='%h_%cI')" \
         -tags osusergo,netgo,sqlite_omit_load_extension \
         -ldflags='-extldflags=-static' \
         ./cmd/goatcounter
@@ -181,7 +187,7 @@ it:
 
 3. You can compile goatcounter without cgo if you don't use SQLite:
 
-       $ CGO_ENABLED=0 go build
+       $ CGO_ENABLED=0 go build -ldflags="-X main.version=$(git log -n1 --format='%h_%cI')" ./cmd/goatcounter
 
    Functionally it doesn't matter too much, but builds will be a bit easier and
    faster as it won't require a C compiler.

--- a/cmd/goatcounter/saas.go
+++ b/cmd/goatcounter/saas.go
@@ -12,6 +12,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/go-chi/chi"
 	"github.com/teamwork/reload"
 	"zgo.at/blackmail"
 	"zgo.at/errors"
@@ -161,10 +162,12 @@ func saas() (int, error) {
 	// Set up HTTP handler and servers.
 	d := zhttp.RemovePort(cfg.Domain)
 	hosts := map[string]http.Handler{
-		zhttp.RemovePort(cfg.DomainStatic): handlers.NewStatic("./public", cfg.Domain, !dev),
-		d:                                  zhttp.RedirectHost("//www." + cfg.Domain),
-		"www." + d:                         handlers.NewWebsite(db),
-		"*":                                handlers.NewBackend(db, acmeh),
+		d:          zhttp.RedirectHost("//www." + cfg.Domain),
+		"www." + d: handlers.NewWebsite(db),
+		"*":        handlers.NewBackend(db, acmeh),
+	}
+	if dev {
+		hosts[zhttp.RemovePort(cfg.DomainStatic)] = handlers.NewStatic(chi.NewRouter(), "./public", !dev)
 	}
 
 	zlog.Module("main").Debug(getVersion())

--- a/cmd/goatcounter/serve.go
+++ b/cmd/goatcounter/serve.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/go-chi/chi"
 	"zgo.at/goatcounter"
 	"zgo.at/goatcounter/acme"
 	"zgo.at/goatcounter/bgrun"
@@ -153,7 +154,9 @@ func serve() (int, error) {
 		"*": handlers.NewBackend(db, acmeh),
 	}
 	if cfg.DomainStatic != "" {
-		hosts[zhttp.RemovePort(cfg.DomainStatic)] = handlers.NewStatic("./public", cfg.Domain, !dev)
+		// May not be needed, but just in case the DomainStatic isn't an
+		// external CDN.
+		hosts[zhttp.RemovePort(cfg.DomainStatic)] = handlers.NewStatic(chi.NewRouter(), "./public", !dev)
 	}
 
 	cnames, err := lsSites(db)

--- a/go.mod
+++ b/go.mod
@@ -27,7 +27,7 @@ require (
 	zgo.at/json v0.0.0-20200627042140-d5025253667f
 	zgo.at/tz v0.0.0-20200520034804-aeba38d94d93
 	zgo.at/zdb v0.0.0-20200713161035-cc5d1b167eb1
-	zgo.at/zhttp v0.0.0-20200713005744-beb9ac646890
+	zgo.at/zhttp v0.0.0-20200718075539-ebbf6909eb4f
 	zgo.at/zli v0.0.0-20200711054229-0ce80f3f667a
 	zgo.at/zlog v0.0.0-20200519105857-4dc5e4ffe04c
 	zgo.at/zpack v1.0.1

--- a/go.sum
+++ b/go.sum
@@ -126,12 +126,10 @@ zgo.at/json v0.0.0-20200627042140-d5025253667f h1:o4XL0oDtAzxN+mkVCti8MYz5nLNfbr
 zgo.at/json v0.0.0-20200627042140-d5025253667f/go.mod h1:DUuNIRpNC7/cup+Gy0qhwQEjjlLFXXRZ04VnVv9bf3E=
 zgo.at/tz v0.0.0-20200520034804-aeba38d94d93 h1:9jisiomiXkQ2K2yTJQOO5fL+Txg+rKxytHj8G8kRl2M=
 zgo.at/tz v0.0.0-20200520034804-aeba38d94d93/go.mod h1:A/XeaYjeMGoXptRB3EcR80tgir37tJnzCb6itDaHPxo=
-zgo.at/zdb v0.0.0-20200704013256-53f5f3182386 h1:4uqJQOMBQbjBBAZYbONeXnaAdHP5mhOHf+mW/K1sC4U=
-zgo.at/zdb v0.0.0-20200704013256-53f5f3182386/go.mod h1:qBj20DkzhioyoAgkqCNNrQYtU9dkaQXU6kko5B36zbg=
 zgo.at/zdb v0.0.0-20200713161035-cc5d1b167eb1 h1:oJOsNjUuL0aZLa045+XbMuyDulTG2Nhx0zi7Vf80ztQ=
 zgo.at/zdb v0.0.0-20200713161035-cc5d1b167eb1/go.mod h1:qBj20DkzhioyoAgkqCNNrQYtU9dkaQXU6kko5B36zbg=
-zgo.at/zhttp v0.0.0-20200713005744-beb9ac646890 h1:DbL9EoqLCHCAgf0OpKJWqbDEi+Ts2CR6bajHenNrnjE=
-zgo.at/zhttp v0.0.0-20200713005744-beb9ac646890/go.mod h1:zt8XaGW1mJoxBWQICtEQlh4RMQYqIyATprZjq7tca2A=
+zgo.at/zhttp v0.0.0-20200718075539-ebbf6909eb4f h1:qv7qMaLMLSUfZ14Ug5/ptLqd3k+wTklZYR/k7s4W/+M=
+zgo.at/zhttp v0.0.0-20200718075539-ebbf6909eb4f/go.mod h1:zt8XaGW1mJoxBWQICtEQlh4RMQYqIyATprZjq7tca2A=
 zgo.at/zli v0.0.0-20200711054229-0ce80f3f667a h1:Z0Tvxgou6ve4S6T+9Ynu1C/pcCGLKf2yaeNxk0uOyl8=
 zgo.at/zli v0.0.0-20200711054229-0ce80f3f667a/go.mod h1:iCNHeIhEG9nQZsmEvf1BDpnQXvbYbUDvokRSwB434M8=
 zgo.at/zlog v0.0.0-20200404052423-adffcc8acd57 h1:sIuh9IpccNlzMsmAvF7EPT87/Ab2XdUJHizsMxbQgM4=


### PR DESCRIPTION
The /count.js has a short expiry of just a day, this way people will get
a cached version when navigating the page, but you won't run in to
problems if count.js adds a new feature and people still use an old
version which doesn't send the new data (resulting in wrong/outdated
data).

The rest will be cached for 30 days; the static files in the backend are
served with a "cache busting" query parameter:

    http://new.arp242.net:8081/all.min.css?v=95da6e2_2020-07-16T21%3a44%3a33%2b08%3a00

So a longer cache should be fine. Note that the default version of this
is "dev", and you must set it at compile-time, so update the README and
mention in CHANGELOG that people need to do this.

Fixes #342 