### PR TITLE
Add Render Deployment option

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -94,7 +94,7 @@ Generally speaking only the latest release is supported, although critical fixes
 
 ### One Click Deployment
 
-You can use [Render's](https://render.com/) one-click deploy button to get up and running with GoatCounter in minutes!
+You can use [Render's](https://render.com/) one-click deploy button to easily get up and running with GoatCounter.
 
 [![Deploy to Render](https://render.com/images/deploy-to-render-button.svg)](https://render.com/deploy?repo=https://github.com/render-examples/goatcounter)
 
@@ -104,7 +104,7 @@ You can use [Render's](https://render.com/) one-click deploy button to get up an
 
 3. Click Approve
 
-That's it! Once the service is deployed, you can access the service using the URL at the top of your service dashboard. Go to your `https://goatcounter-xyz.onrender.com` address, log in using the credentials you just provided and start using GoatCounter on Render!
+Once the service is deployed, you can access the service using the URL at the top of your service dashboard and login using the credentials you just provided.
 
 ### Building from source
 

--- a/README.markdown
+++ b/README.markdown
@@ -92,6 +92,20 @@ Generally speaking only the latest release is supported, although critical fixes
 [releases]: https://github.com/zgoat/goatcounter/releases
 [r-1.3]: https://github.com/zgoat/goatcounter/tree/release-1.3
 
+### One Click Deployment
+
+You can use [Render's](https://render.com/) one-click deploy button to get up and running with GoatCounter in minutes!
+
+[![Deploy to Render](https://render.com/images/deploy-to-render-button.svg)](https://render.com/deploy?repo=https://github.com/render-examples/goatcounter)
+
+1. Click **Deploy to Render** above and create an account if you haven't already done so.
+
+2. Enter values for the `GC_USER_EMAIL` and `GC_PASSWORD` environment variables to create your GoatCounter account.
+
+3. Click Approve
+
+That's it! Once the service is deployed, you can access the service using the URL at the top of your service dashboard. Go to your `https://goatcounter-xyz.onrender.com` address, log in using the credentials you just provided and start using GoatCounter on Render!
+
 ### Building from source
 
 Compile from source with:


### PR DESCRIPTION
Hello. I'm an engineer at [Render](https://render.com/). We recently set up a one-click deployment button that makes it super simple for your users to get up and running in just a couple minutes. I was hoping you would be willing to add us as an option in your readme. 

I'm happy to address any questions or concerns!