### PR TITLE
Show row numbers

### DIFF
--- a/handlers/backend.go
+++ b/handlers/backend.go
@@ -367,22 +367,21 @@ func (h backend) pages(w http.ResponseWriter, r *http.Request) error {
 	}
 
 	tpl, err := ztpl.ExecuteString("_dashboard_pages_rows.gohtml", struct {
-		Context      context.Context
-		Pages        goatcounter.HitStats
-		Site         *goatcounter.Site
-		PeriodStart  time.Time
-		PeriodEnd    time.Time
-		Daily        bool
-		ForcedDaily  bool
-		Max          int
-		IsPagination bool
-		Offset       int
+		Context     context.Context
+		Pages       goatcounter.HitStats
+		Site        *goatcounter.Site
+		PeriodStart time.Time
+		PeriodEnd   time.Time
+		Daily       bool
+		ForcedDaily bool
+		Max         int
+		Offset      int
 
 		// Dummy values so template won't error out.
 		Refs     bool
 		ShowRefs string
-	}{r.Context(), pages, site, start, end,
-		daily, forcedDaily, int(max), true, offset, false, ""})
+	}{r.Context(), pages, site, start, end, daily, forcedDaily, int(max),
+		offset, false, ""})
 	if err != nil {
 		return err
 	}

--- a/handlers/backend.go
+++ b/handlers/backend.go
@@ -299,6 +299,12 @@ func (h backend) pages(w http.ResponseWriter, r *http.Request) error {
 	}
 	max := int(m)
 
+	o, err := strconv.ParseInt(r.URL.Query().Get("offset"), 10, 64)
+	if err != nil {
+		o = 1
+	}
+	offset := int(o)
+
 	// Load new totals unless this is for pagination.
 	var (
 		wg sync.WaitGroup
@@ -370,12 +376,13 @@ func (h backend) pages(w http.ResponseWriter, r *http.Request) error {
 		ForcedDaily  bool
 		Max          int
 		IsPagination bool
+		Offset       int
 
 		// Dummy values so template won't error out.
 		Refs     bool
 		ShowRefs string
 	}{r.Context(), pages, site, start, end,
-		daily, forcedDaily, int(max), true, false, ""})
+		daily, forcedDaily, int(max), true, offset, false, ""})
 	if err != nil {
 		return err
 	}

--- a/handlers/dashboard.go
+++ b/handlers/dashboard.go
@@ -224,13 +224,12 @@ func (h backend) dashboard(w http.ResponseWriter, r *http.Request) error {
 					TotalUniqueHits int
 					MorePages       bool
 
-					Refs         goatcounter.Stats
-					ShowRefs     string
-					IsPagination bool
+					Refs     goatcounter.Stats
+					ShowRefs string
 				}{r.Context(), data.pages.pages, site, start, end, daily,
 					forcedDaily, 1, data.pages.max, data.pages.display,
 					data.pages.uniqueDisplay, data.total, data.totalUnique,
-					data.pages.more, data.pages.refs, showRefs, false}
+					data.pages.more, data.pages.refs, showRefs}
 			},
 			"totalpages": func() (string, string, interface{}) {
 				return "full-width", "_dashboard_totals.gohtml", struct {

--- a/handlers/dashboard.go
+++ b/handlers/dashboard.go
@@ -214,6 +214,7 @@ func (h backend) dashboard(w http.ResponseWriter, r *http.Request) error {
 					PeriodEnd   time.Time
 					Daily       bool
 					ForcedDaily bool
+					Offset      int
 					Max         int
 
 					TotalDisplay       int
@@ -226,10 +227,10 @@ func (h backend) dashboard(w http.ResponseWriter, r *http.Request) error {
 					Refs         goatcounter.Stats
 					ShowRefs     string
 					IsPagination bool
-				}{r.Context(), data.pages.pages, site, start, end, daily, forcedDaily, data.pages.max,
-					data.pages.display, data.pages.uniqueDisplay,
-					data.total, data.totalUnique, data.pages.more,
-					data.pages.refs, showRefs, false}
+				}{r.Context(), data.pages.pages, site, start, end, daily,
+					forcedDaily, 1, data.pages.max, data.pages.display,
+					data.pages.uniqueDisplay, data.total, data.totalUnique,
+					data.pages.more, data.pages.refs, showRefs, false}
 			},
 			"totalpages": func() (string, string, interface{}) {
 				return "full-width", "_dashboard_totals.gohtml", struct {

--- a/pack/pack.go
+++ b/pack/pack.go
@@ -12101,6 +12101,7 @@ http://nicolasgallagher.com/micro-clearfix-hack/
 						daily:   $('#daily').is(':checked'),
 						exclude: $('.count-list-pages >tbody >tr').toArray().map((e) => e.id).join(','),
 						max:     get_original_scale(),
+						offset:  $('.count-list-pages >tbody >tr').length + 1,
 					}),
 					success: function(data) {
 						update_pages(data, false)
@@ -13042,6 +13043,7 @@ tr.target .chart-left { display: block; }
 	position: absolute; right: .4em; top: -.8em; padding: 0 .1em; font-size: 1.2rem; text-align: center;
 	background-color: #fff;
 }
+.page-n { color: #555; font-size: .8em; }
 
 .chart-bar             { display: flex; align-items: flex-end; }
 .chart-bar > div       { position: relative; flex-grow: 1; background: #9a15a4; }
@@ -15233,7 +15235,10 @@ want to modify that in JavaScript; you can use <code>goatcounter.endpoint</code>
 			</div>
 			<div class="chart chart-bar" data-max="{{$h.Max}}">
 				<span class="chart-left"><a href="#" class="rescale" title="Scale Y axis to max">↕️&#xfe0e;</a></span>
-				{{if and (not $.IsPagination) (eq $i 0)}}<span class="chart-right"><small class="scale" title="Y-axis scale">{{nformat $.Max $.Site}}</small></span>{{end}}
+				<span class="chart-right">
+					{{- if (eq $i 0)}}<small class="scale" title="Y-axis scale">{{nformat $.Max $.Site}}</small>
+					{{- else if $.IsPagination}}<span class="page-n" title="Page ranking">#{{sum $.Offset $i}}</span>{{end -}}
+				</span>
 				<span class="half"></span>
 				{{bar_chart $.Context .Stats $.Max $.Daily}}
 			</div>

--- a/pack/pack.go
+++ b/pack/pack.go
@@ -15235,9 +15235,9 @@ want to modify that in JavaScript; you can use <code>goatcounter.endpoint</code>
 			</div>
 			<div class="chart chart-bar" data-max="{{$h.Max}}">
 				<span class="chart-left"><a href="#" class="rescale" title="Scale Y axis to max">↕️&#xfe0e;</a></span>
-				<span class="chart-right">
+				<span class="chart-right">{{$n := sum $.Offset $i}}
 					{{- if (eq $i 0)}}<small class="scale" title="Y-axis scale">{{nformat $.Max $.Site}}</small>
-					{{- else if $.IsPagination}}<span class="page-n" title="Page ranking">#{{sum $.Offset $i}}</span>{{end -}}
+					{{- else if ge $n 11}}<span class="page-n" title="Page ranking">#{{$n}}</span>{{end -}}
 				</span>
 				<span class="half"></span>
 				{{bar_chart $.Context .Stats $.Max $.Daily}}

--- a/public/script_backend.js
+++ b/public/script_backend.js
@@ -254,6 +254,7 @@
 						daily:   $('#daily').is(':checked'),
 						exclude: $('.count-list-pages >tbody >tr').toArray().map((e) => e.id).join(','),
 						max:     get_original_scale(),
+						offset:  $('.count-list-pages >tbody >tr').length + 1,
 					}),
 					success: function(data) {
 						update_pages(data, false)

--- a/public/style_backend.css
+++ b/public/style_backend.css
@@ -163,6 +163,7 @@ tr.target .chart-left { display: block; }
 	position: absolute; right: .4em; top: -.8em; padding: 0 .1em; font-size: 1.2rem; text-align: center;
 	background-color: #fff;
 }
+.page-n { color: #555; font-size: .8em; }
 
 .chart-bar             { display: flex; align-items: flex-end; }
 .chart-bar > div       { position: relative; flex-grow: 1; background: #9a15a4; }

--- a/tpl/_dashboard_pages_rows.gohtml
+++ b/tpl/_dashboard_pages_rows.gohtml
@@ -23,7 +23,10 @@
 			</div>
 			<div class="chart chart-bar" data-max="{{$h.Max}}">
 				<span class="chart-left"><a href="#" class="rescale" title="Scale Y axis to max">↕️&#xfe0e;</a></span>
-				{{if and (not $.IsPagination) (eq $i 0)}}<span class="chart-right"><small class="scale" title="Y-axis scale">{{nformat $.Max $.Site}}</small></span>{{end}}
+				<span class="chart-right">
+					{{- if (eq $i 0)}}<small class="scale" title="Y-axis scale">{{nformat $.Max $.Site}}</small>
+					{{- else if $.IsPagination}}<span class="page-n" title="Page ranking">#{{sum $.Offset $i}}</span>{{end -}}
+				</span>
 				<span class="half"></span>
 				{{bar_chart $.Context .Stats $.Max $.Daily}}
 			</div>

--- a/tpl/_dashboard_pages_rows.gohtml
+++ b/tpl/_dashboard_pages_rows.gohtml
@@ -23,9 +23,9 @@
 			</div>
 			<div class="chart chart-bar" data-max="{{$h.Max}}">
 				<span class="chart-left"><a href="#" class="rescale" title="Scale Y axis to max">↕️&#xfe0e;</a></span>
-				<span class="chart-right">
+				<span class="chart-right">{{$n := sum $.Offset $i}}
 					{{- if (eq $i 0)}}<small class="scale" title="Y-axis scale">{{nformat $.Max $.Site}}</small>
-					{{- else if $.IsPagination}}<span class="page-n" title="Page ranking">#{{sum $.Offset $i}}</span>{{end -}}
+					{{- else if ge $n 11}}<span class="page-n" title="Page ranking">#{{$n}}</span>{{end -}}
 				</span>
 				<span class="half"></span>
 				{{bar_chart $.Context .Stats $.Max $.Daily}}


### PR DESCRIPTION
Add row numbers, but only when paginating. This still keeps a fairly
simple overview on the initial load, and gives some more context when
you've paginated a few times.

Also repeat the Y-axis scale when paginating on the first new row, for
clarity.

Fixes #352 