### PR TITLE
Add API to send pageviews from backend

### DIFF
--- a/CHANGELOG.markdown
+++ b/CHANGELOG.markdown
@@ -26,7 +26,7 @@ master branch
 
   TOTP-based multi-factor auth is now supported.
 
-- Better export, add import feature export API (#316, #318)
+- Better export, export API, add import feature (#316, #318)
 
   You can now import the CSV exports, useful for migrating from self-hosted to
   goatcounter.com or vice verse, or for migrating from other systems.
@@ -37,6 +37,12 @@ master branch
   platform.
 
   See http://goatcounter.com/api for details.
+
+- API for sending pageviews (#357)
+
+  Doing that with the regular `/count` is actually quite painful, as you quickly
+  run in to ratelimits, need to set specific headers, etc. Adding an API
+  endpoint for that makes things much easier.
 
 - Some redesigns (#324, #315, #321 #320)
 
@@ -54,8 +60,6 @@ master branch
 
   Previously the EUPL applied, which is fairly restrictive and may prevent
   people from including/self-hosting the count.js script.
-
-- Offer some data files for download (#319)
 
 
 2020-06-01 v1.3.0

--- a/cmd/goatcounter/monitor_test.go
+++ b/cmd/goatcounter/monitor_test.go
@@ -25,7 +25,7 @@ func TestMonitor(t *testing.T) {
 
 	t.Run("with pageviews", func(t *testing.T) {
 		ctx, site := gctest.Site(ctx, t, goatcounter.Site{})
-		gctest.StoreHits(ctx, t, goatcounter.Hit{Path: "/", Site: site.ID})
+		gctest.StoreHits(ctx, t, false, goatcounter.Hit{Path: "/", Site: site.ID})
 
 		run(t, 0, []string{"monitor",
 			"-db", dbc,

--- a/cron/hit_stat_test.go
+++ b/cron/hit_stat_test.go
@@ -21,7 +21,7 @@ func TestHitStats(t *testing.T) {
 	site := goatcounter.MustGetSite(ctx)
 	now := time.Date(2019, 8, 31, 14, 42, 0, 0, time.UTC)
 
-	gctest.StoreHits(ctx, t, []goatcounter.Hit{
+	gctest.StoreHits(ctx, t, false, []goatcounter.Hit{
 		{Site: site.ID, CreatedAt: now, Path: "/asd", Title: "aSd", FirstVisit: true},
 		{Site: site.ID, CreatedAt: now, Path: "/asd/"}, // Trailing / should be sanitized and treated identical as /asd
 		{Site: site.ID, CreatedAt: now, Path: "/zxc"},

--- a/cron/tasks_test.go
+++ b/cron/tasks_test.go
@@ -30,7 +30,7 @@ func TestDataRetention(t *testing.T) {
 	now := time.Now().UTC()
 	past := now.Add(-40 * 24 * time.Hour)
 
-	gctest.StoreHits(ctx, t, []goatcounter.Hit{
+	gctest.StoreHits(ctx, t, false, []goatcounter.Hit{
 		{Site: site.ID, CreatedAt: now, Path: "/a", FirstVisit: zdb.Bool(true)},
 		{Site: site.ID, CreatedAt: now, Path: "/a", FirstVisit: zdb.Bool(false)},
 		{Site: site.ID, CreatedAt: past, Path: "/a", FirstVisit: zdb.Bool(true)},

--- a/docs/api.html
+++ b/docs/api.html
@@ -125,6 +125,44 @@
 	
 		
 			</div><div>
+			<h3 id="count" class="js-expand">count
+				<a class="permalink" href="#count">§</a></h3>
+
+		<div class="endpoint" id="POST-/api/v0/count">
+			<div class="endpoint-top">
+				<code class="resource"><span class="method">POST</span> /api/v0/count</code>
+				Count pageviews.
+				<a class="permalink" href="#POST-%2fapi%2fv0%2fcount">§</a>
+			</div>
+			<div class="endpoint-info">
+				<p>This can count one or more pageviews. Pageviews are not persisted immediatly,
+but persisted in the background every 10 seconds.</p><p>The maximum amount of pageviews per request is 100.</p><p>Errors will have the key set to the index of the pageview. Any pageviews not
+listed have been processed and shouldn&#39;t be sent again.</p>
+					<h4>Request body</h4>
+					<ul>
+						<li><a href="#handlers.apiCountRequest">handlers.apiCountRequest</a>
+							<sup>(application/json)</sup></li>
+					</ul>
+
+				<h4>Responses</h4>
+				<ul>
+					<li><code class="param-name">202 Accepted</code>
+								<p>202 Accepted (no data)</p>
+							<sup>(application/json)</sup>
+					</li>
+					<li><code class="param-name">400 Bad Request</code>
+								<a href="#handlers.apiError">handlers.apiError</a>
+							<sup>(application/json)</sup>
+					</li>
+					<li><code class="param-name">403 Forbidden</code>
+								<a href="#handlers.authError">handlers.authError</a>
+							<sup>(application/json)</sup>
+					</li></ul>
+			</div>
+		</div>
+	
+		
+			</div><div>
 			<h3 id="export" class="js-expand">export
 				<a class="permalink" href="#export">§</a></h3>
 
@@ -141,6 +179,14 @@
 				<ul>
 					<li><code class="param-name">200 OK</code>
 								<a href="#goatcounter.Export">goatcounter.Export</a>
+							<sup>(application/json)</sup>
+					</li>
+					<li><code class="param-name">400 Bad Request</code>
+								<a href="#handlers.apiError">handlers.apiError</a>
+							<sup>(application/json)</sup>
+					</li>
+					<li><code class="param-name">403 Forbidden</code>
+								<a href="#handlers.authError">handlers.authError</a>
 							<sup>(application/json)</sup>
 					</li></ul>
 			</div>
@@ -162,6 +208,14 @@
 					<li><code class="param-name">200 OK</code>
 								<p>200 OK (text/csv data)</p>
 							<sup>(text/csv)</sup>
+					</li>
+					<li><code class="param-name">400 Bad Request</code>
+								<a href="#handlers.apiError">handlers.apiError</a>
+							<sup>(application/json)</sup>
+					</li>
+					<li><code class="param-name">403 Forbidden</code>
+								<a href="#handlers.authError">handlers.authError</a>
+							<sup>(application/json)</sup>
 					</li></ul>
 			</div>
 		</div>
@@ -187,6 +241,14 @@
 					<li><code class="param-name">202 Accepted</code>
 								<a href="#goatcounter.Export">goatcounter.Export</a>
 							<sup>(application/json)</sup>
+					</li>
+					<li><code class="param-name">400 Bad Request</code>
+								<a href="#handlers.apiError">handlers.apiError</a>
+							<sup>(application/json)</sup>
+					</li>
+					<li><code class="param-name">403 Forbidden</code>
+								<a href="#handlers.authError">handlers.authError</a>
+							<sup>(application/json)</sup>
 					</li></ul>
 			</div>
 		</div>
@@ -205,8 +267,6 @@
 <p>The hit ID this export was started from.</p>
 <h4>last_hit_id <sup>integer [readonly]</sup></h4>
 <p>Last hit ID that was exported; can be used as start_from_hit_id.</p>
-<h4>path <sup>string [readonly]</sup></h4>
-<p></p>
 <h4>created_at <sup>string [format: date-time] [readonly]</sup></h4>
 <p></p>
 <h4>finished_at <sup>string [format: date-time] [readonly]</sup></h4>
@@ -221,11 +281,76 @@
 <p>Any errors that may have occured.</p>
 
 		</div>
+		<h3 id="handlers.apiCountRequest">handlers.apiCountRequest <a class="permalink" href="#handlers.apiCountRequest">§</a></h3>
+		<div class="endpoint model">
+			<p class="info"></p>
+			<h4>no_sessions <sup>boolean</sup></h4>
+<p>Don&#39;t try to count unique visitors; every pageview will be considered a
+&#34;visit&#34;.</p>
+<h4>hits <sup>array [type: <a href="#handlers.apiCountRequestHit">handlers.apiCountRequestHit</a>]</sup></h4>
+<p></p>
+
+		</div>
+		<h3 id="handlers.apiCountRequestHit">handlers.apiCountRequestHit <a class="permalink" href="#handlers.apiCountRequestHit">§</a></h3>
+		<div class="endpoint model">
+			<p class="info"></p>
+			<h4>path <sup>string [required]</sup></h4>
+<p>Path of the pageview, or the event name.</p>
+<h4>title <sup>string</sup></h4>
+<p>Page title, or some descriptive event title.</p>
+<h4>event <sup>boolean</sup></h4>
+<p>Is this an event?</p>
+<h4>ref <sup>string</sup></h4>
+<p>Referrer value, can be an URL (i.e. the Referal: header) or any
+string.</p>
+<h4>size <sup>array [type: number]</sup></h4>
+<p>Screen size as &#34;x,y,scaling&#34;</p>
+<h4>query <sup>string</sup></h4>
+<p>Query parameters for this pageview, used to get campaign parameters.</p>
+<h4>bot <sup>integer</sup></h4>
+<p>Hint if this should be considered a bot; should be one of the JSBot*`
+constants from isbot; note the backend may override this if it
+detects a bot using another method.
+https://github.com/zgoat/isbot/blob/master/isbot.go#L28</p>
+<h4>user_agent <sup>string</sup></h4>
+<p>User-Agent header.</p>
+<h4>location <sup>string</sup></h4>
+<p>Location as ISO-3166-1 alpha2 string (e.g. NL, ID, etc.)</p>
+<h4>ip <sup>string</sup></h4>
+<p>IP to get location from; not used if location is set. Also used for
+session generation.</p>
+<h4>created_at <sup>string [format: date-time]</sup></h4>
+<p>Time this pageview should be recorded at; this can be in the past,
+but not in the future.</p>
+<h4>session <sup>string</sup></h4>
+<p>Normally a session is based on hash(User-Agent+IP+salt), but if you don&#39;t
+send the IP address then we can&#39;t determine the session.</p><p>In those cases, you can store your own session identifiers and send them
+along. Note these will not be stored in the database as the sessionID
+(just as the hashes aren&#39;t), they&#39;re just used as a unique grouping
+identifier.</p><p>You can also just disable sessions entirely with NoSessions.</p>
+
+		</div>
+		<h3 id="handlers.apiError">handlers.apiError <a class="permalink" href="#handlers.apiError">§</a></h3>
+		<div class="endpoint model">
+			<p class="info"></p>
+			<h4>Error <sup>string</sup></h4>
+<p></p>
+<h4>Errors <sup><a href="#"></a></sup></h4>
+<p></p>
+
+		</div>
 		<h3 id="handlers.apiExportRequest">handlers.apiExportRequest <a class="permalink" href="#handlers.apiExportRequest">§</a></h3>
 		<div class="endpoint model">
 			<p class="info"></p>
 			<h4>start_from_hit_id <sup>integer</sup></h4>
 <p>Pagination cursor; only export hits with an ID greater than this.</p>
+
+		</div>
+		<h3 id="handlers.authError">handlers.authError <a class="permalink" href="#handlers.authError">§</a></h3>
+		<div class="endpoint model">
+			<p class="info"></p>
+			<h4>Error <sup>string</sup></h4>
+<p></p>
 
 		</div>
 

--- a/docs/api.json
+++ b/docs/api.json
@@ -2,10 +2,11 @@
   "swagger": "2.0",
   "info": {
     "title": "GoatCounter",
+    "description": "API for GoatCounter",
     "version": "0.1",
     "contact": {
       "name": "Martin Tournoij",
-      "url": "https://www.goatcounter.com",
+      "url": "https://www.goatcounter.com/api",
       "email": "support@goatcounter.com"
     }
   },
@@ -17,10 +18,56 @@
   ],
   "tags": [
     {
+      "name": "count"
+    },
+    {
       "name": "export"
     }
   ],
   "paths": {
+    "/api/v0/count": {
+      "post": {
+        "consumes": [
+          "application/json"
+        ],
+        "description": "This can count one or more pageviews. Pageviews are not persisted immediatly,\nbut persisted in the background every 10 seconds.\n\nThe maximum amount of pageviews per request is 100.\n\nErrors will have the key set to the index of the pageview. Any pageviews not\nlisted have been processed and shouldn't be sent again.",
+        "operationId": "POST_api_v0_count",
+        "parameters": [
+          {
+            "in": "body",
+            "name": "handlers.apiCountRequest",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/handlers.apiCountRequest"
+            }
+          }
+        ],
+        "produces": [
+          "application/json"
+        ],
+        "responses": {
+          "202": {
+            "description": "202 Accepted (no data)"
+          },
+          "400": {
+            "description": "400 Bad Request",
+            "schema": {
+              "$ref": "#/definitions/handlers.apiError"
+            }
+          },
+          "403": {
+            "description": "403 Forbidden",
+            "schema": {
+              "$ref": "#/definitions/handlers.authError"
+            }
+          }
+        },
+        "summary": "Count pageviews.",
+        "tags": [
+          "count"
+        ]
+      }
+    },
     "/api/v0/export": {
       "post": {
         "consumes": [
@@ -46,6 +93,18 @@
             "description": "202 Accepted",
             "schema": {
               "$ref": "#/definitions/goatcounter.Export"
+            }
+          },
+          "400": {
+            "description": "400 Bad Request",
+            "schema": {
+              "$ref": "#/definitions/handlers.apiError"
+            }
+          },
+          "403": {
+            "description": "403 Forbidden",
+            "schema": {
+              "$ref": "#/definitions/handlers.authError"
             }
           }
         },
@@ -75,6 +134,18 @@
             "schema": {
               "$ref": "#/definitions/goatcounter.Export"
             }
+          },
+          "400": {
+            "description": "400 Bad Request",
+            "schema": {
+              "$ref": "#/definitions/handlers.apiError"
+            }
+          },
+          "403": {
+            "description": "403 Forbidden",
+            "schema": {
+              "$ref": "#/definitions/handlers.authError"
+            }
           }
         },
         "summary": "Get details about an export.",
@@ -95,11 +166,24 @@
           }
         ],
         "produces": [
+          "application/json",
           "text/csv"
         ],
         "responses": {
           "200": {
             "description": "200 OK (text/csv data)"
+          },
+          "400": {
+            "description": "400 Bad Request",
+            "schema": {
+              "$ref": "#/definitions/handlers.apiError"
+            }
+          },
+          "403": {
+            "description": "403 Forbidden",
+            "schema": {
+              "$ref": "#/definitions/handlers.authError"
+            }
           }
         },
         "summary": "Download an export file.",
@@ -147,10 +231,6 @@
           "type": "integer",
           "readOnly": true
         },
-        "path": {
-          "type": "string",
-          "readOnly": true
-        },
         "site_id": {
           "type": "integer",
           "readOnly": true
@@ -166,6 +246,95 @@
         }
       }
     },
+    "handlers.apiCountRequest": {
+      "title": "apiCountRequest",
+      "type": "object",
+      "properties": {
+        "hits": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/handlers.apiCountRequestHit"
+          }
+        },
+        "no_sessions": {
+          "description": "Don't try to count unique visitors; every pageview will be considered a\n\"visit\".",
+          "type": "boolean"
+        }
+      }
+    },
+    "handlers.apiCountRequestHit": {
+      "title": "apiCountRequestHit",
+      "type": "object",
+      "required": [
+        "path"
+      ],
+      "properties": {
+        "bot": {
+          "description": "Hint if this should be considered a bot; should be one of the JSBot*`\nconstants from isbot; note the backend may override this if it\ndetects a bot using another method.\nhttps://github.com/zgoat/isbot/blob/master/isbot.go#L28",
+          "type": "integer"
+        },
+        "created_at": {
+          "description": "Time this pageview should be recorded at; this can be in the past,\nbut not in the future.",
+          "type": "string",
+          "format": "date-time"
+        },
+        "event": {
+          "description": "Is this an event?",
+          "type": "boolean"
+        },
+        "ip": {
+          "description": "IP to get location from; not used if location is set. Also used for\nsession generation.",
+          "type": "string"
+        },
+        "location": {
+          "description": "Location as ISO-3166-1 alpha2 string (e.g. NL, ID, etc.)",
+          "type": "string"
+        },
+        "path": {
+          "description": "Path of the pageview, or the event name.",
+          "type": "string"
+        },
+        "query": {
+          "description": "Query parameters for this pageview, used to get campaign parameters.",
+          "type": "string"
+        },
+        "ref": {
+          "description": "Referrer value, can be an URL (i.e. the Referal: header) or any\nstring.",
+          "type": "string"
+        },
+        "session": {
+          "description": "Normally a session is based on hash(User-Agent+IP+salt), but if you don't\nsend the IP address then we can't determine the session.\n\nIn those cases, you can store your own session identifiers and send them\nalong. Note these will not be stored in the database as the sessionID\n(just as the hashes aren't), they're just used as a unique grouping\nidentifier.\n\nYou can also just disable sessions entirely with NoSessions.",
+          "type": "string"
+        },
+        "size": {
+          "description": "Screen size as \"x,y,scaling\"",
+          "type": "array",
+          "items": {
+            "type": "number"
+          }
+        },
+        "title": {
+          "description": "Page title, or some descriptive event title.",
+          "type": "string"
+        },
+        "user_agent": {
+          "description": "User-Agent header.",
+          "type": "string"
+        }
+      }
+    },
+    "handlers.apiError": {
+      "title": "apiError",
+      "type": "object",
+      "properties": {
+        "Error": {
+          "type": "string"
+        },
+        "Errors": {
+          "type": "object"
+        }
+      }
+    },
     "handlers.apiExportRequest": {
       "title": "apiExportRequest",
       "type": "object",
@@ -173,6 +342,15 @@
         "start_from_hit_id": {
           "description": "Pagination cursor; only export hits with an ID greater than this.",
           "type": "integer"
+        }
+      }
+    },
+    "handlers.authError": {
+      "title": "authError",
+      "type": "object",
+      "properties": {
+        "Error": {
+          "type": "string"
         }
       }
     }

--- a/export.go
+++ b/export.go
@@ -39,7 +39,7 @@ type Export struct {
 	// Last hit ID that was exported; can be used as start_from_hit_id.
 	LastHitID *int64 `db:"last_hit_id" json:"last_hit_id,readonly"`
 
-	Path      string    `db:"path" json:"path,readonly"`
+	Path      string    `db:"path" json:"path,readonly"` // {omitdoc}
 	CreatedAt time.Time `db:"created_at" json:"created_at,readonly"`
 
 	FinishedAt *time.Time `db:"finished_at" json:"finished_at,readonly"`

--- a/export_test.go
+++ b/export_test.go
@@ -27,7 +27,7 @@ func TestExport(t *testing.T) {
 
 	d1 := time.Date(2019, 6, 18, 0, 0, 0, 0, time.UTC)
 	d2 := time.Date(2019, 6, 19, 0, 0, 0, 0, time.UTC)
-	gctest.StoreHits(ctx, t, []goatcounter.Hit{
+	gctest.StoreHits(ctx, t, false, []goatcounter.Hit{
 		{Path: "/asd", CreatedAt: d1},
 		{Path: "/zxc", CreatedAt: d1},
 		{Path: "/asd", CreatedAt: d2},

--- a/gen.go
+++ b/gen.go
@@ -70,12 +70,15 @@ var (
 
 func kommentaar() error {
 	commands := map[string][]string{
-		"docs/api.json": {"-config", "./kommentaar.conf", "-output", "openapi2-jsonindent", "./handlers"},
-		"docs/api.html": {"-config", "./kommentaar.conf", "-output", "html", "./handlers"},
+		"docs/api.json": {"-config", "../kommentaar.conf", "-output", "openapi2-jsonindent", "."},
+		"docs/api.html": {"-config", "../kommentaar.conf", "-output", "html", "."},
 	}
 
 	for file, args := range commands {
-		out, err := exec.Command("kommentaar", args...).CombinedOutput()
+		cmd := exec.Command("kommentaar", args...)
+		cmd.Dir = "./handlers"
+
+		out, err := cmd.CombinedOutput()
 		if err != nil {
 			return errors.Errorf("running kommentaar: %s\n%s", err, out)
 		}

--- a/go.mod
+++ b/go.mod
@@ -14,7 +14,7 @@ require (
 	github.com/mattn/go-sqlite3 v1.14.0
 	github.com/monoculum/formam v0.0.0-20200527175922-6f3cce7a46cf
 	github.com/teamwork/reload v1.3.2
-	github.com/zgoat/kommentaar v0.0.0-20200718094027-9fe5c6e0bb9a
+	github.com/zgoat/kommentaar v0.0.0-20200723124016-8596c8d73b76
 	golang.org/x/crypto v0.0.0-20200709230013-948cd5f35899
 	golang.org/x/net v0.0.0-20200707034311-ab3426394381
 	golang.org/x/sync v0.0.0-20200625203802-6e8e738ad208
@@ -28,7 +28,7 @@ require (
 	zgo.at/json v0.0.0-20200627042140-d5025253667f
 	zgo.at/tz v0.0.0-20200520034804-aeba38d94d93
 	zgo.at/zdb v0.0.0-20200721051833-b17e8bb8e4ed
-	zgo.at/zhttp v0.0.0-20200725090804-7949f8934b53
+	zgo.at/zhttp v0.0.0-20200725161002-9f61b6a71947
 	zgo.at/zli v0.0.0-20200723211721-b6f2723c0e9c
 	zgo.at/zlog v0.0.0-20200519105857-4dc5e4ffe04c
 	zgo.at/zpack v1.0.1

--- a/go.sum
+++ b/go.sum
@@ -47,8 +47,8 @@ github.com/rogpeppe/go-internal v1.3.0/go.mod h1:M8bDsm7K2OlrFYOpmOWEs/qY81heoFR
 github.com/teamwork/reload v1.3.2 h1:Cfo305GjPi859SWLzh728H/4ovl1qkDndv48QFRjLLA=
 github.com/teamwork/reload v1.3.2/go.mod h1:xR3BcLHeCmLBX/2jKDG2vWOLTcql3+aah4puN18lmTo=
 github.com/yuin/goldmark v1.1.32/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
-github.com/zgoat/kommentaar v0.0.0-20200718094027-9fe5c6e0bb9a h1:+wS7oO1/W8WupBntIvu3fK7IW4jUtj02XEMNtH79a4M=
-github.com/zgoat/kommentaar v0.0.0-20200718094027-9fe5c6e0bb9a/go.mod h1:+d9niCygXFwu5mKfCcyiTRdlXUH1U+CmFdG7lV3MBZo=
+github.com/zgoat/kommentaar v0.0.0-20200723124016-8596c8d73b76 h1:UTzytzD1rEuIYLl5EvaN9uCKUyUFrLiUPqQtNKfmCD0=
+github.com/zgoat/kommentaar v0.0.0-20200723124016-8596c8d73b76/go.mod h1:7xhbAqcgV+9q20XCx0c2SWzJrklgwke/29Ah57LDsNU=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2 h1:VklqNMn3ovrHsnt90PveolxSbWFaJdECFbxSq0Mqo2M=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
 golang.org/x/crypto v0.0.0-20190510104115-cbcb75029529/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
@@ -118,8 +118,8 @@ zgo.at/tz v0.0.0-20200520034804-aeba38d94d93 h1:9jisiomiXkQ2K2yTJQOO5fL+Txg+rKxy
 zgo.at/tz v0.0.0-20200520034804-aeba38d94d93/go.mod h1:A/XeaYjeMGoXptRB3EcR80tgir37tJnzCb6itDaHPxo=
 zgo.at/zdb v0.0.0-20200721051833-b17e8bb8e4ed h1:V+V2RMn8n6xBKnBZERZ9i4mvx9Zx4AhaLv6R7ZczhYA=
 zgo.at/zdb v0.0.0-20200721051833-b17e8bb8e4ed/go.mod h1:qBj20DkzhioyoAgkqCNNrQYtU9dkaQXU6kko5B36zbg=
-zgo.at/zhttp v0.0.0-20200725090804-7949f8934b53 h1:0DVzQDSmXa/wVXXoz0TFvQz51jsm/y+honyBHU2qEYk=
-zgo.at/zhttp v0.0.0-20200725090804-7949f8934b53/go.mod h1:4vN9RqtJXa0XePvaoFV03A88KvqUokFkJ0Z+86b1r6M=
+zgo.at/zhttp v0.0.0-20200725161002-9f61b6a71947 h1:31i3NSX0Wb07MqTJQrgXzQNLeA+LKrNqf58UdK/kKB8=
+zgo.at/zhttp v0.0.0-20200725161002-9f61b6a71947/go.mod h1:4vN9RqtJXa0XePvaoFV03A88KvqUokFkJ0Z+86b1r6M=
 zgo.at/zli v0.0.0-20200723211721-b6f2723c0e9c h1:M1QjVzl8njZGW//fNb0bW1EI3pwBDQkMJEQoEMVy3+s=
 zgo.at/zli v0.0.0-20200723211721-b6f2723c0e9c/go.mod h1:iCNHeIhEG9nQZsmEvf1BDpnQXvbYbUDvokRSwB434M8=
 zgo.at/zlog v0.0.0-20200404052423-adffcc8acd57 h1:sIuh9IpccNlzMsmAvF7EPT87/Ab2XdUJHizsMxbQgM4=
@@ -129,14 +129,12 @@ zgo.at/zlog v0.0.0-20200519105857-4dc5e4ffe04c/go.mod h1:YkLAQZjLsp1RqWHn8SJokHz
 zgo.at/zpack v1.0.1 h1:muDVwpdzfC/1+U2rsTsv0feI82zxMq0CZuHPZ9RTwJ8=
 zgo.at/zpack v1.0.1/go.mod h1:2laAAHqImmeiTlMAQ2PlMRBVhS6YKPkUoosMfdv7GXY=
 zgo.at/zstd v0.0.0-20200602040707-aaf6806a6bf5/go.mod h1:wSF/3tBbAJVo+RYk5CTMmSN2xxyy4C+qTb5fN4WP9iA=
-zgo.at/zstd v0.0.0-20200718091649-a5714a091965/go.mod h1:wSF/3tBbAJVo+RYk5CTMmSN2xxyy4C+qTb5fN4WP9iA=
+zgo.at/zstd v0.0.0-20200718115135-a1fc42b2004d/go.mod h1:wSF/3tBbAJVo+RYk5CTMmSN2xxyy4C+qTb5fN4WP9iA=
 zgo.at/zstd v0.0.0-20200725081511-350d4ae0eb40 h1:6THn+vWRhVyjGPA6n8SIPQjFifenECa+Kq6VSyp5FzE=
 zgo.at/zstd v0.0.0-20200725081511-350d4ae0eb40/go.mod h1:bQqcOgaRPCBT7lZ52Ksg9GF1xwi0L97E3AyvW3oGJYE=
 zgo.at/zstripe v1.0.0 h1:rfBrWEUpveYFZKNo4rdc3Fvhb9LEzbMIyL76EXAmXDk=
 zgo.at/zstripe v1.0.0/go.mod h1:EqblFpMvXAhzZAUUt0EVom06EnN5+D5ESBTSOkwSwTY=
-zgo.at/ztest v0.0.0-20200316134318-cfad86d80b41 h1:2vR+4hRs2YI2Lcm68AjHLSOHxQy/3XJ/b2nCV/dCrxs=
 zgo.at/ztest v0.0.0-20200316134318-cfad86d80b41/go.mod h1:xGKONSdBgBNBcHRbi+yY9xFSre7ip8gRsQBS9QW/J2I=
-zgo.at/ztest v0.0.0-20200526130303-f59d60374e72 h1:eJi5pmYHERPsQ9a7Sw1HW8GXTVFWlHQ+EfZKSzx1Y+Y=
 zgo.at/ztest v0.0.0-20200526130303-f59d60374e72/go.mod h1:xGKONSdBgBNBcHRbi+yY9xFSre7ip8gRsQBS9QW/J2I=
 zgo.at/ztest v0.0.0-20200630024640-d19d80ca68af h1:R4x8P0jEUonoCtK3OGMVJ1Iwq7oMqJDSyBvw8r8b+Zk=
 zgo.at/ztest v0.0.0-20200630024640-d19d80ca68af/go.mod h1:xGKONSdBgBNBcHRbi+yY9xFSre7ip8gRsQBS9QW/J2I=

--- a/handlers/api_test.go
+++ b/handlers/api_test.go
@@ -7,11 +7,13 @@ package handlers
 import (
 	"bytes"
 	"context"
+	"fmt"
 	"io"
 	"net/http"
 	"net/http/httptest"
 	"strings"
 	"testing"
+	"time"
 
 	"zgo.at/goatcounter"
 	"zgo.at/goatcounter/gctest"
@@ -119,6 +121,21 @@ func TestAPIBasics(t *testing.T) {
 			}
 		})
 
+		t.Run("invalid json", func(t *testing.T) {
+			ctx, clean, r, rr := newAPITest(t, "POST", "/api/v0/test",
+				strings.NewReader(`{{{{`),
+				goatcounter.APITokenPermissions{})
+			defer clean()
+
+			newBackend(zdb.MustGet(ctx)).ServeHTTP(rr, r)
+			ztest.Code(t, rr, 400)
+
+			want := `{"error":"invalid JSON:`
+			if !strings.HasPrefix(rr.Body.String(), want) {
+				t.Errorf("\nwant: %s\ngot:  %s\n", want, rr.Body.String())
+			}
+		})
+
 		t.Run("panic", func(t *testing.T) {
 			ctx, clean, r, rr := newAPITest(t, "POST", "/api/v0/test",
 				strings.NewReader(`{"panic":true}`),
@@ -191,4 +208,127 @@ func TestAPIBasics(t *testing.T) {
 		newBackend(zdb.MustGet(ctx)).ServeHTTP(rr, r)
 		ztest.Code(t, rr, 200)
 	})
+}
+
+func TestAPICount(t *testing.T) {
+	tests := []struct {
+		body     apiCountRequest
+		wantCode int
+		wantRet  string
+		want     string
+	}{
+		{apiCountRequest{}, 400, `{"error":"no hits"}`, ""},
+
+		// {
+		// 	apiCountRequest{NoSessions: true, Hits: []apiCountRequestHit{
+		// 		{Path: "/", CreatedAt: goatcounter.Now().Add(5 * time.Minute)},
+		// 	}}, 400, `{"errors":{"0":"created_at: in the future.\n"}}`, "",
+		// },
+
+		{
+			apiCountRequest{NoSessions: true, Hits: []apiCountRequestHit{
+				{Path: "/foo"},
+				{Path: "/bar", CreatedAt: time.Date(2020, 1, 18, 14, 42, 0, 0, time.UTC)},
+			}},
+			202, respOK, `
+			id  site  session  path  title  event  bot  ref  ref_scheme  browser  size  location  first_visit  created_at           session2
+			1   1     NULL     /foo         0      0         NULL                                 1            2020-06-18 14:42:00  00112233445566778899aabbccddef01
+			2   1     NULL     /bar         0      0         NULL                                 1            2020-01-18 14:42:00  00112233445566778899aabbccddef01
+			`,
+		},
+
+		// Fill in most fields.
+		{
+			apiCountRequest{NoSessions: true, Hits: []apiCountRequestHit{
+				{Path: "/foo", Title: "A", Ref: "y", UserAgent: "Mozilla/5.0 (Linux) Firefox/1", Location: "ET", Size: zdb.Floats{42, 666, 2}},
+			}},
+			202, respOK, `
+			id  site  session  path  title  event  bot  ref  ref_scheme  browser                        size      location  first_visit  created_at           session2
+			1   1     NULL     /foo  A      0      0    y    o           Mozilla/5.0 (Linux) Firefox/1  42,666,2  ET        1            2020-06-18 14:42:00  00112233445566778899aabbccddef01
+			`,
+		},
+
+		// Event
+		{
+			apiCountRequest{NoSessions: true, Hits: []apiCountRequestHit{
+				{Event: zdb.Bool(true), Path: "/foo", Title: "A", Ref: "y", UserAgent: "Mozilla/5.0 (Linux) Firefox/1", Location: "ET", Size: zdb.Floats{42, 666, 2}},
+			}},
+			202, respOK, `
+			id  site  session  path  title  event  bot  ref  ref_scheme  browser                        size      location  first_visit  created_at           session2
+			1   1     NULL     foo   A      1      0    y    o           Mozilla/5.0 (Linux) Firefox/1  42,666,2  ET        1            2020-06-18 14:42:00  00112233445566778899aabbccddef01
+			`,
+		},
+
+		// Calculate session from IP+UserAgent
+		{
+			apiCountRequest{Hits: []apiCountRequestHit{
+				{Path: "/foo", UserAgent: "Mozilla/5.0 (Linux) Firefox/1", IP: "66.66.66.66"},
+				{Path: "/foo", UserAgent: "Mozilla/5.0 (Linux) Firefox/1", IP: "66.66.66.67"},
+				{Path: "/foo", UserAgent: "Mozilla/5.0 (Linux) Firefox/1", IP: "66.66.66.66"},
+			}},
+			202, respOK, `
+			id  site  session  path  title  event  bot  ref  ref_scheme  browser                        size  location  first_visit  created_at           session2
+			1   1     NULL     /foo         0      0         NULL        Mozilla/5.0 (Linux) Firefox/1        US        1            2020-06-18 14:42:00  00112233445566778899aabbccddef01
+			2   1     NULL     /foo         0      0         NULL        Mozilla/5.0 (Linux) Firefox/1        US        1            2020-06-18 14:42:00  00112233445566778899aabbccddef02
+			3   1     NULL     /foo         0      0         NULL        Mozilla/5.0 (Linux) Firefox/1        US        0            2020-06-18 14:42:00  00112233445566778899aabbccddef01
+			`,
+		},
+
+		// UserSessionID
+		{
+			apiCountRequest{Hits: []apiCountRequestHit{
+				{Path: "/foo", Session: "a"},
+				{Path: "/foo", Session: "b"},
+				{Path: "/foo", Session: "a"},
+			}},
+			202, respOK, `
+			id  site  session  path  title  event  bot  ref  ref_scheme  browser  size  location  first_visit  created_at           session2
+			1   1     NULL     /foo         0      0         NULL                                 1            2020-06-18 14:42:00  00112233445566778899aabbccddef01
+			2   1     NULL     /foo         0      0         NULL                                 1            2020-06-18 14:42:00  00112233445566778899aabbccddef02
+			3   1     NULL     /foo         0      0         NULL                                 0            2020-06-18 14:42:00  00112233445566778899aabbccddef01
+			`,
+		},
+
+		// Don't persist if session is blank.
+		{
+			apiCountRequest{Hits: []apiCountRequestHit{
+				{Path: "/foo", Session: "a"},
+				{Path: "/foo"},
+			}},
+			400, `{"errors":{"1":"session or browser/IP not set; use no_sessions if you don't want to track unique visits"}}`, `
+			id  site  session  path  title  event  bot  ref  ref_scheme  browser  size  location  first_visit  created_at           session2
+			1   1     NULL     /foo         0      0         NULL                                 1            2020-06-18 14:42:00  00112233445566778899aabbccddef01
+			`,
+		},
+	}
+
+	defer gctest.SwapNow(t, "2020-06-18 14:42:00")()
+	perm := goatcounter.APITokenPermissions{Count: true}
+
+	for i, tt := range tests {
+		t.Run(fmt.Sprintf("%d", i), func(t *testing.T) {
+			ctx, clean, r, rr := newAPITest(t, "POST", "/api/v0/count",
+				bytes.NewReader(zjson.MustMarshal(tt.body)), perm)
+			defer clean()
+
+			newBackend(zdb.MustGet(ctx)).ServeHTTP(rr, r)
+			ztest.Code(t, rr, tt.wantCode)
+			if rr.Body.String() != tt.wantRet {
+				t.Errorf("\nout:  %s\nwant: %s", rr.Body.String(), tt.wantRet)
+			}
+
+			gctest.StoreHits(ctx, t, false)
+
+			tt.want = strings.TrimSpace(strings.ReplaceAll(tt.want, "\t", ""))
+			got := strings.TrimSpace(zdb.DumpString(ctx, `select * from hits`))
+			if strings.Count(got, "\n") == 0 { // No data, only the header.
+				got = ""
+			}
+
+			if d := ztest.Diff(got, tt.want); d != "" {
+				t.Errorf(d)
+				fmt.Println(got)
+			}
+		})
+	}
 }

--- a/handlers/website.go
+++ b/handlers/website.go
@@ -81,7 +81,7 @@ func (h website) Mount(r *chi.Mux, db zdb.DB) {
 	conf := srvhttp.Args{
 		Packages: []string{"./handlers"},
 		Config:   "./kommentaar.conf",
-		NoScan:   cfg.Prod,
+		NoScan:   true, // TODO: Kommentaar doesn't resolve correctly in modules, need chdir()
 		JSONFile: "./docs/api.json",
 		HTMLFile: "./docs/api.html",
 	}

--- a/hit.go
+++ b/hit.go
@@ -49,7 +49,8 @@ type Hit struct {
 	Random string   `db:"-" json:"rnd"` // Browser cache buster, as they don't always listen to Cache-Control
 
 	// Some values we need to pass from the HTTP handler to memstore
-	RemoteAddr string `db:"-" json:"-"`
+	RemoteAddr    string `db:"-" json:"-"`
+	UserSessionID string `db:"-" json:"-"`
 }
 
 func (h *Hit) cleanPath(ctx context.Context) {

--- a/hit_test.go
+++ b/hit_test.go
@@ -167,7 +167,7 @@ func TestHitStatsList(t *testing.T) {
 			}
 			site.Settings.Limits.Page = 2
 
-			gctest.StoreHits(ctx, t, tt.in...)
+			gctest.StoreHits(ctx, t, false, tt.in...)
 
 			var stats goatcounter.HitStats
 			totalDisplay, uniqueDisplay, more, err := stats.List(ctx, start, end, tt.inFilter, tt.inExclude, false)

--- a/kommentaar.conf
+++ b/kommentaar.conf
@@ -1,16 +1,18 @@
 # vim:ft=config
 
 title                GoatCounter
+description          API for GoatCounter
 version              0.1
 contact-name         Martin Tournoij
 contact-email        support@goatcounter.com
-contact-site         https://www.goatcounter.com
+contact-site         https://www.goatcounter.com/api
 
 default-request-ct   application/json
 default-response-ct  application/json
 
-#default-response 400: github.com/teamwork/validate.Validator
-#default-response 404 (application/json): github.com/teamwork/apiutil/errorhandler.Error
+default-response 400: zgo.at/goatcounter/handlers.apiError
+default-response 403: zgo.at/goatcounter/handlers.authError
+add-default-response 400 403
 
 map-types
     time.Time string

--- a/tpl/_backend_sitecode.gohtml
+++ b/tpl/_backend_sitecode.gohtml
@@ -487,34 +487,11 @@ regular browsers).</p>
 <p>Wrap in a <code>&lt;noscript&gt;</code> tag to use this only for people without JavaScript.</p>
 
 <h3 id="tracking-from-backend-middleware">Tracking from backend middleware <a href="#tracking-from-backend-middleware"></a></h3>
-<p>You can call <code>GET {{.Site.URL}}/count</code> or <code>POST {{.Site.URL}}/count</code> from
-anywhere, such as your app’s middleware. The GET and POST endpoints are
-identical, and support the following query parameters (form parameters are
-ignored for POST):</p>
+<p>You can use the <code>/api/v0/count</code> API endpoint to send pageviews from essentially
+anywhere, such as you app's middleware.</p>
 
-<ul>
-  <li><code>p</code> → <code>path</code></li>
-  <li><code>e</code> → <code>event</code></li>
-  <li><code>t</code> → <code>title</code></li>
-  <li><code>r</code> → <code>referrer</code></li>
-  <li><code>s</code> → screen size, as <code>x,y,scaling</code>.</li>
-  <li><code>q</code> → Query parameters, for getting the campaign.</li>
-  <li><code>b</code> → hint if this should be considered a bot; should be one of the
-      <a href="https://github.com/zgoat/isbot/blob/master/isbot.go#L28"><code>JSBot*</code> constants from isbot</a>; note the backend may override
-      this if it detects a bot using another method.</li>
-  <li><code>rnd</code> → can be used as a “cache buster” since browsers don’t always obey
-        <code>Cache-Control</code>; ignored by the backend.</li>
-</ul>
-
-<p>You’ll need to forward the <code>User-Agent</code> header from the client and IP as
-<code>X-Forwarded-For: &lt;ip&gt;</code> if you want to get the correct browser and location.</p>
-
-<p><strong>NOTE</strong>: many client libraries (such as <code>curl</code>) are marked as bots by default;
-be sure to use a vaguely realistic <code>User-Agent</code> when testing or if you’re not
-forwarding the user’s <code>User-Agent</code> header.</p>
-
-<p>Calling it from the middleware will probably result in more bot requests, as
-mentioned in the previous section.</p>
+<p>The <a href="https://www.goatcounter.com/api">API documentation</a> contains more
+information and some examples.</p>
 
 <h3 id="location-of-countjs-and-loading-it-locally">Location of count.js and loading it locally <a href="#location-of-countjs-and-loading-it-locally"></a></h3>
 <p>You can load the <code>count.js</code> script anywhere on your page, but it’s recommended

--- a/tpl/_backend_sitecode.markdown
+++ b/tpl/_backend_sitecode.markdown
@@ -396,34 +396,11 @@ regular browsers).
 Wrap in a `<noscript>` tag to use this only for people without JavaScript.
 
 ### Tracking from backend middleware
-You can call `GET {{.Site.URL}}/count` or `POST {{.Site.URL}}/count` from
-anywhere, such as your app’s middleware. The GET and POST endpoints are
-identical, and support the following query parameters (form parameters are
-ignored for POST):
+You can use the `/api/v0/count` API endpoint to send pageviews from essentially
+anywhere, such as you app's middleware.
 
-- `p` → `path`
-- `e` → `event`
-- `t` → `title`
-- `r` → `referrer`
-- `s` → screen size, as `x,y,scaling`.
-- `q` → Query parameters, for getting the campaign.
-- `b` → hint if this should be considered a bot; should be one of the
-        [`JSBot*` constants from isbot][isbot]; note the backend may override
-        this if it detects a bot using another method.
-- `rnd` → can be used as a “cache buster” since browsers don’t always obey
-          `Cache-Control`; ignored by the backend.
-
-You’ll need to forward the `User-Agent` header from the client and IP as
-`X-Forwarded-For: <ip>` if you want to get the correct browser and location.
-
-**NOTE**: many client libraries (such as `curl`) are marked as bots by default;
-be sure to use a vaguely realistic `User-Agent` when testing or if you’re not
-forwarding the user’s `User-Agent` header.
-
-Calling it from the middleware will probably result in more bot requests, as
-mentioned in the previous section.
-
-[isbot]: https://github.com/zgoat/isbot/blob/master/isbot.go#L28
+The [API documentation](https://www.goatcounter.com/api) contains more
+information and some examples.
 
 ### Location of count.js and loading it locally
 You can load the `count.js` script anywhere on your page, but it’s recommended

--- a/tpl/api.gohtml
+++ b/tpl/api.gohtml
@@ -3,14 +3,23 @@
 *************************************************************************/}}
 
 {{template "_top.gohtml" .}}
+{{define "sh_header"}}#!/bin/sh<br />
+token=[your api token]
+api=https://[my code].goatcounter.com/api/v0
+curl() {
+    \command curl \
+        -H 'Content-Type: application/json' \
+        -H "Authorization: Bearer $token" \
+        "$@"
+}{{end}}
 
 <h1 id="goatcounter-api">GoatCounter API</h1>
 <p>GoatCounter has a rudimentary API; this is far from feature-complete, but solves
 some common use cases.</p>
 
-<p>The API is currently unversioned and prefixed with <code>/api/v0</code>; while breaking
-changes will be avoided and are not expected, they <em>may</em> occur. I'll be sure to
-send ample notification of this to everyone who has generated an API key.</p>
+<p>The API is currently unversioned and prefixed with <code>/api/v0</code>; breaking changes
+will be avoided and are not expected but <em>may</em> occur. I'll be sure to send ample
+notification of this to everyone who has generated an API key.</p>
 
 <h2 id="authentication">Authentication <a href="#authentication"></a></h2>
 <p>To use the API create a key in your account (<code>Settings → Password, MFA, API</code>);
@@ -22,23 +31,47 @@ unless noted otherwise.</p>
 
 <p>Example:</p>
 
-<pre><code>curl -X POST \
+<pre><code>curl -X POST https://example.goatcounter.com/api/v0/export \
     -H 'Content-Type: application/json' \
-    -H 'Authorization: Bearer 2q2snk7clgqs63tr4xc5bwseajlw88qzilr8fq157jz3qxwwmz5' \
-    https://example.goatcounter.com/api/v0/export
+    -H 'Authorization: Bearer 2q2snk7clgqs63tr4xc5bwseajlw88qzilr8fq157jz3qxwwmz5'
 </code></pre>
+
+<p>Replace the key and URL with your actual values.</p>
 
 <h2 id="rate-limit">Rate limit <a href="#rate-limit"></a></h2>
 <p>The rate limit is 60 requests per 120 seconds. The current rate limits are
 indicated in the <code>X-Rate-Limit-Limit</code>, <code>X-Rate-Limit-Remaining</code>, and
 <code>X-Rate-Limit-Reset</code> headers.</p>
 
+<h2 id="errors">Errors <a href="#errors"></a></h2>
+<p>Errors are reported in either an <code>error</code> or <code>errors</code> field; the <code>error</code> field
+always contains a string; for example:</p>
+
+<pre><code>{
+    "error": "oh noes!"
+}
+</code></pre>
+
+<p>The <code>errors</code> field contains an object with a list:</p>
+
+<pre><code>{
+    "errors": {
+        "key":     ["error1", "error2"],
+        "another": ["oh noes!"]
+    }
+}
+</code></pre>
+
+<p>A status code in the <code>2xx</code> range will never contain errors, a status code in the
+<code>4xx</code> or <code>5xx</code> range will always have either <code>error</code> or <code>errors</code>, but never
+both. There may also be additional data in other fields on errors.</p>
+
 <h2 id="api-reference">API reference <a href="#api-reference"></a></h2>
 <p>API reference docs are available at:</p>
 
 <ul>
   <li><a href="/api.json">/api.json</a> – OpenAPI 2.0 JSON file.</li>
-  <li><a href="/api.html">/api.html</a> – Basic HTML.</li>
+  <li><a href="/api.html">/api.html</a> – Basic HTML (still kinda ugly 😅).</li>
   <li><a href="https://app.swaggerhub.com/apis-docs/Carpetsmoker/GoatCounter/0.1">SwaggerHub</a></li>
 </ul>
 
@@ -46,18 +79,25 @@ indicated in the <code>X-Rate-Limit-Limit</code>, <code>X-Rate-Limit-Remaining</
 
 <h2 id="examples">Examples <a href="#examples"></a></h2>
 
+<h3 id="backend-integration">Backend integration <a href="#backend-integration"></a></h3>
+<p>You can use <code>/api/v0/count</code> to send requests from your backend. This is the same
+as <code>/count</code> but has higher rate-limits, allows setting some additional fields,
+and allows batching multiple pageviews in one request.</p>
+
+<p>Detail are available in the <a href="/api.html#count">API reference</a>, a simple example
+might look like:</p>
+
+<pre><code>{{template "sh_header" .}}
+
+curl -X POST  "$api/count" \
+    --data '{"no_sessions": true, "hits": [{"path": "/one"}, {"path": "/two"}]}'
+</code></pre>
+
 <h3 id="export">Export <a href="#export"></a></h3>
 
 <p>Example to export via the API:</p>
 
-<pre><code>token=[your api token]
-api=http://[my code].goatcounter.com/api/v0
-curl() {
-    \command curl --silent \
-        -H 'Content-Type: application/json' \
-        -H "Authorization: Bearer $token" \
-        $@
-}
+<pre><code>{{template "sh_header" .}}
 
 # Start a new export, get ID from response object.
 id=$(curl -X POST "$api/export" | jq .id)
@@ -77,8 +117,7 @@ done
 </code></pre>
 
 <p>The above doesn't does no error checking for brevity: errors are reported in the
-<code>error</code> field as a string, or in the <code>errors</code> field as <code>{"name": ["err1",
-"err2", "name2": [..]}</code>.</p>
+<code>error</code> or <code>errors</code> field as described above.</p>
 
 <p>The export object contains a <code>last_hit_id</code> parameter, which can be used as a
 pagination cursor to only download hits after this export. This is useful to
@@ -88,7 +127,7 @@ sync your local database every hour or so:</p>
 start=$(curl "$api/export/$id" | jq .last_hit_id)
 
 # Start new export starting from the cursor.
-id=$(curl -X POST --data "{\"start_from_hit_id\":$start}" "$api/export" | jq .id)
+id=$(curl -X POST "$api/export" --data "{\"start_from_hit_id\":$start}" | jq .id)
 </code></pre>
 
 {{template "_bottom.gohtml" .}}

--- a/tpl/api.markdown
+++ b/tpl/api.markdown
@@ -1,13 +1,23 @@
 {{template "%%top.gohtml" .}}
+{{define "sh_header"}}#!/bin/sh<br>
+token=\[your api token]
+api=https://\[my code].goatcounter.com/api/v0
+curl() {
+    \command curl \
+        -H 'Content-Type: application/json' \
+        -H "Authorization: Bearer $token" \
+        "$@"
+}{{end}}
 
 GoatCounter API
 ===============
 GoatCounter has a rudimentary API; this is far from feature-complete, but solves
 some common use cases.
 
-The API is currently unversioned and prefixed with `/api/v0`; while breaking
-changes will be avoided and are not expected, they *may* occur. I'll be sure to
-send ample notification of this to everyone who has generated an API key.
+The API is currently unversioned and prefixed with `/api/v0`; breaking changes
+will be avoided and are not expected but *may* occur. I'll be sure to send ample
+notification of this to everyone who has generated an API key.
+
 
 Authentication
 --------------
@@ -20,10 +30,12 @@ unless noted otherwise.
 
 Example:
 
-    curl -X POST \
+    curl -X POST https://example.goatcounter.com/api/v0/export \
         -H 'Content-Type: application/json' \
-        -H 'Authorization: Bearer 2q2snk7clgqs63tr4xc5bwseajlw88qzilr8fq157jz3qxwwmz5' \
-        https://example.goatcounter.com/api/v0/export
+        -H 'Authorization: Bearer 2q2snk7clgqs63tr4xc5bwseajlw88qzilr8fq157jz3qxwwmz5'
+
+Replace the key and URL with your actual values.
+
 
 Rate limit
 ----------
@@ -31,31 +43,62 @@ The rate limit is 60 requests per 120 seconds. The current rate limits are
 indicated in the `X-Rate-Limit-Limit`, `X-Rate-Limit-Remaining`, and
 `X-Rate-Limit-Reset` headers.
 
+
+Errors
+------
+Errors are reported in either an `error` or `errors` field; the `error` field
+always contains a string; for example:
+
+    {
+        "error": "oh noes!"
+    }
+
+The `errors` field contains an object with a list:
+
+    {
+        "errors": {
+            "key":     ["error1", "error2"],
+            "another": ["oh noes!"]
+        }
+    }
+
+A status code in the `2xx` range will never contain errors, a status code in the
+`4xx` or `5xx` range will always have either `error` or `errors`, but never
+both. There may also be additional data in other fields on errors.
+
+
 API reference
 -------------
 API reference docs are available at:
 
 - [/api.json](/api.json) – OpenAPI 2.0 JSON file.
-- [/api.html](/api.html) – Basic HTML.
+- [/api.html](/api.html) – Basic HTML (still kinda ugly 😅).
 - [SwaggerHub](https://app.swaggerhub.com/apis-docs/Carpetsmoker/GoatCounter/0.1)
 
 The files are also available in the `docs` directory of the source repository.
 
+
 Examples
 --------
+
+### Backend integration
+You can use `/api/v0/count` to send requests from your backend. This is the same
+as `/count` but has higher rate-limits, allows setting some additional fields,
+and allows batching multiple pageviews in one request.
+
+Detail are available in the [API reference](/api.html#count), a simple example
+might look like:
+
+    {{template "sh_header" .}}
+
+    curl -X POST  "$api/count" \
+        --data '{"no_sessions": true, "hits": [{"path": "/one"}, {"path": "/two"}]}'
 
 ### Export
 
 Example to export via the API:
 
-    token=[your api token]
-    api=http://[my code].goatcounter.com/api/v0
-    curl() {
-        \command curl --silent \
-            -H 'Content-Type: application/json' \
-            -H "Authorization: Bearer $token" \
-            $@
-    }
+    {{template "sh_header" .}}
 
     # Start a new export, get ID from response object.
     id=$(curl -X POST "$api/export" | jq .id)
@@ -74,8 +117,7 @@ Example to export via the API:
     done
 
 The above doesn't does no error checking for brevity: errors are reported in the
-`error` field as a string, or in the `errors` field as `{"name": ["err1",
-"err2", "name2": [..]}`.
+`error` or `errors` field as described above.
 
 The export object contains a `last_hit_id` parameter, which can be used as a
 pagination cursor to only download hits after this export. This is useful to
@@ -85,6 +127,6 @@ sync your local database every hour or so:
     start=$(curl "$api/export/$id" | jq .last_hit_id)
 
     # Start new export starting from the cursor.
-    id=$(curl -X POST --data "{\"start_from_hit_id\":$start}" "$api/export" | jq .id)
+    id=$(curl -X POST "$api/export" --data "{\"start_from_hit_id\":$start}" | jq .id)
 
 {{template "%%bottom.gohtml" .}}

--- a/tpl/backend_settings.gohtml
+++ b/tpl/backend_settings.gohtml
@@ -404,10 +404,8 @@
 								<input type="text" id="name" name="name" placeholder="Name">
 							</td>
 							<td>
-								{{/*
 								<label title="Record pageviews with /api/v0/count">
 									<input type="checkbox" name="permissions.count">Record pageviews</label><br>
-								*/}}
 								<label title="Export data with /api/v0/export">
 									<input type="checkbox" name="permissions.export">Export</label>
 							</td>

--- a/tpl/help.gohtml
+++ b/tpl/help.gohtml
@@ -6,6 +6,7 @@
 	Other documentation pages:<br>
 	<a href="/gdpr">GDPR consent notices</a> |
 	<a href="/code">Site integration code</a> |
+	<a href="/api">API</a> |
 	<a href="/privacy">Privacy policy</a> |
 	<a href="/terms">Terms of use</a>
 </p>

--- a/tplfunc.go
+++ b/tplfunc.go
@@ -31,7 +31,7 @@ func init() {
 	tplfunc.Add("base32", base32.StdEncoding.WithPadding(base32.NoPadding).EncodeToString)
 	tplfunc.Add("validate", zvalidate.TemplateError)
 	tplfunc.Add("has_errors", zvalidate.TemplateHasErrors)
-	tplfunc.Add("error_code", func(err error) string { return zhttp.ErrorCode(err) })
+	tplfunc.Add("error_code", func(err error) string { return zhttp.UserErrorCode(err) })
 	tplfunc.Add("parent_site", func(ctx context.Context, id *int64) string {
 		var s Site
 		err := s.ByID(ctx, *id)


### PR DESCRIPTION
Doing that with the regular /count is actually quite painful, as you
quickly run in to ratelimits, need to set specific headers, etc.