### PR TITLE
Fix a bug with local subsite links.

### DIFF
--- a/tpl/backend_settings.gohtml
+++ b/tpl/backend_settings.gohtml
@@ -193,7 +193,7 @@
 							<td><a href="//{{$s.Code}}.{{$.Domain}}">{{$s.Code}}</a></td>
 							<td><a href="/remove/{{$s.ID}}">delete</a></td>
 						{{else}}
-							<td><a href="//{{$s.URL}}">{{$s.URL}}</a></td>
+							<td><a href="{{$s.URL}}">{{$s.URL}}</a></td>
 							<td><a href="/remove/{{$s.ID}}">delete</a></td>
 						{{end}}
 					</tr>{{end}}


### PR DESCRIPTION
Currently subsite links don't work when self-hosting. This is
because the template includes a leading `//` before the full
`site.URL()`, which already includes the site protocol. This
results in a link to something like `http://http://hostname`,
which the browser has trouble with.

This fixes the bug by simply removing the leading `//` in the,
template relying on `site.URL()` to be a fully qualified and 
navigable URL that includes the protocol.

Let me know if there's UI tests in place that I should extend
as part of this.