### PR TITLE
Fix typo in signup page

### DIFF
--- a/tpl/signup.gohtml
+++ b/tpl/signup.gohtml
@@ -21,7 +21,7 @@
 					<label for="link_domain">Site domain</label>
 					<input type="text" name="link_domain" id="link_domain" maxlength="255" value="{{.Site.LinkDomain}}">
 					{{validate "site.link_domain" .Validate}}
-					<span class="help">Your site’s domain, used for display/linlking; optional.</em></span>
+					<span class="help">Your site’s domain, used for display/linking; optional.</em></span>
 				</div>
 
 			</div>


### PR DESCRIPTION
You have an unfortunate typo in your signup page, "linlking". This pull request just fixes the typo.