### PR TITLE
Refactor "goatcounter import" a bit

### DIFF
--- a/cmd/goatcounter/buffer.go
+++ b/cmd/goatcounter/buffer.go
@@ -132,8 +132,6 @@ func buffer() (int, error) {
 		}
 	}()
 
-	fmt.Println(os.Getpid())
-
 	dbConnect := flagDB()
 	debug := flagDebug()
 

--- a/cron/tasks.go
+++ b/cron/tasks.go
@@ -94,7 +94,11 @@ func (l *lastMemstore) Set(t time.Time) {
 	l.t = t
 }
 
-var LastMemstore lastMemstore
+var LastMemstore = func() *lastMemstore {
+	l := &lastMemstore{}
+	l.Set(goatcounter.Now())
+	return l
+}()
 
 func PersistAndStat(ctx context.Context) error {
 	l := zlog.Module("cron")

--- a/export_test.go
+++ b/export_test.go
@@ -133,7 +133,11 @@ func TestExport(t *testing.T) {
 		defer gzfp.Close()
 
 		cron.RunBackground(zdb.MustGet(ctx))
-		goatcounter.Import(ctx, gzfp, true, false)
+		goatcounter.Import(ctx, gzfp, true, false, func(hit goatcounter.Hit, final bool) {
+			if !final {
+				goatcounter.Memstore.Append(hit)
+			}
+		})
 
 		_, err = goatcounter.Memstore.Persist(ctx)
 		if err != nil {

--- a/pack/pack.go
+++ b/pack/pack.go
@@ -15445,10 +15445,8 @@ id=$(curl -X POST "$api/export" --data "{\"start_from_hit_id\":$start}" | jq .id
 			</div>
 			<div class="endpoint-info">
 				<p>This can count one or more pageviews. Pageviews are not persisted
-immediately, but persisted in the background every 10 seconds.</p><p>The maximum amount of pageviews per request is 100.</p><p>Errors will have the key set to the index of the pageview. Any pageviews not
-listed have been processed and shouldn&#39;t be sent again.</p><p>The response header has the X-Goatcounter-Memstore header set to the time of
-the last time pageviews were persisted to the database. This is useful if you
-want to (roughly) sync up with this.</p>
+immediately, but persisted in the background every 10 seconds.</p><p>The maximum amount of pageviews per request is 500.</p><p>Errors will have the key set to the index of the pageview. Any pageviews not
+listed have been processed and shouldn&#39;t be sent again.</p>
 					<h4>Request body</h4>
 					<ul>
 						<li><a href="#handlers.APICountRequest">handlers.APICountRequest</a>
@@ -16080,7 +16078,7 @@ depending on whether daylight savings time is in use at the time instant.</p>
         "consumes": [
           "application/json"
         ],
-        "description": "This can count one or more pageviews. Pageviews are not persisted\nimmediately, but persisted in the background every 10 seconds.\n\nThe maximum amount of pageviews per request is 100.\n\nErrors will have the key set to the index of the pageview. Any pageviews not\nlisted have been processed and shouldn't be sent again.\n\nThe response header has the X-Goatcounter-Memstore header set to the time of\nthe last time pageviews were persisted to the database. This is useful if you\nwant to (roughly) sync up with this.",
+        "description": "This can count one or more pageviews. Pageviews are not persisted\nimmediately, but persisted in the background every 10 seconds.\n\nThe maximum amount of pageviews per request is 500.\n\nErrors will have the key set to the index of the pageview. Any pageviews not\nlisted have been processed and shouldn't be sent again.",
         "operationId": "POST_api_v0_count",
         "parameters": [
           {

--- a/tpl/api.html
+++ b/tpl/api.html
@@ -135,10 +135,8 @@
 			</div>
 			<div class="endpoint-info">
 				<p>This can count one or more pageviews. Pageviews are not persisted
-immediately, but persisted in the background every 10 seconds.</p><p>The maximum amount of pageviews per request is 100.</p><p>Errors will have the key set to the index of the pageview. Any pageviews not
-listed have been processed and shouldn&#39;t be sent again.</p><p>The response header has the X-Goatcounter-Memstore header set to the time of
-the last time pageviews were persisted to the database. This is useful if you
-want to (roughly) sync up with this.</p>
+immediately, but persisted in the background every 10 seconds.</p><p>The maximum amount of pageviews per request is 500.</p><p>Errors will have the key set to the index of the pageview. Any pageviews not
+listed have been processed and shouldn&#39;t be sent again.</p>
 					<h4>Request body</h4>
 					<ul>
 						<li><a href="#handlers.APICountRequest">handlers.APICountRequest</a>

--- a/tpl/api.json
+++ b/tpl/api.json
@@ -36,7 +36,7 @@
         "consumes": [
           "application/json"
         ],
-        "description": "This can count one or more pageviews. Pageviews are not persisted\nimmediately, but persisted in the background every 10 seconds.\n\nThe maximum amount of pageviews per request is 100.\n\nErrors will have the key set to the index of the pageview. Any pageviews not\nlisted have been processed and shouldn't be sent again.\n\nThe response header has the X-Goatcounter-Memstore header set to the time of\nthe last time pageviews were persisted to the database. This is useful if you\nwant to (roughly) sync up with this.",
+        "description": "This can count one or more pageviews. Pageviews are not persisted\nimmediately, but persisted in the background every 10 seconds.\n\nThe maximum amount of pageviews per request is 500.\n\nErrors will have the key set to the index of the pageview. Any pageviews not\nlisted have been processed and shouldn't be sent again.",
         "operationId": "POST_api_v0_count",
         "parameters": [
           {


### PR DESCRIPTION
- Read .gz CSV files
- Don't wait so much; it's really not needed.
- Lower rate limits.
- Refactor a bit to make it easie to add logfile support.