### PR TITLE
Add autofocus to email and TOTP fields

### DIFF
--- a/tpl/_backend_signin.gohtml
+++ b/tpl/_backend_signin.gohtml
@@ -1,6 +1,6 @@
 <form method="post" action="/user/requestlogin" class="vertical">
 	<label for="email">Email address</label>
-	<input type="email" name="email" id="email" value="{{.Email}}" required><br>
+	<input type="email" name="email" id="email" value="{{.Email}}" autofocus required><br>
 
 	<label for="password">Password</label>
 	<input type="password" name="password" id="password" required

--- a/tpl/totp.gohtml
+++ b/tpl/totp.gohtml
@@ -8,7 +8,7 @@ your authenticator app.</p>
 	<input type="hidden" id="loginmac" name="loginmac" value="{{ .LoginMAC }}">
 	<label for="totp_token">MFA Token</label>
 	<input type="text" name="totp_token" id="totp_token"
-		inputmode="numeric" pattern="[0-9]*"
+		inputmode="numeric" pattern="[0-9]*" autofocus
 		required autocomplete="one-time-code"><br>
 	<button>Sign in</button>
 </form>


### PR DESCRIPTION
This will help typing in these fields as it's not necessary
to manually focus them before typing.

Also, since (at least my) password manager copies the TOTP code to
the clipboard when autofilling entries, this has the benefit
of also not having to manually focus the TOTP field before pasting.