### PR TITLE
Fix typo in visitor counter markdown

### DIFF
--- a/tpl/code/visitor-counter.markdown
+++ b/tpl/code/visitor-counter.markdown
@@ -132,4 +132,4 @@ A simple example usage:
         })
         r.open('GET', '{{.SiteURL}}/counter/' + encodeURIComponent(location.pathname) + '.json')
         r.send()
-    </scrip>
+    </script>


### PR DESCRIPTION
This PR aims to fix the typo that was present in the `script` tag.