### PR TITLE
Allow privately sharing a link with a secret token

### DIFF
--- a/db/migrate/2021-06-27-1-public-postgres.sql
+++ b/db/migrate/2021-06-27-1-public-postgres.sql
@@ -1,0 +1,2 @@
+update sites set settings = jsonb_set(settings, '{public}', '"public"')  where settings->'public' = 'true';
+update sites set settings = jsonb_set(settings, '{public}', '"private"') where settings->'public' = 'false';

--- a/db/migrate/2021-06-27-1-public-sqlite.sql
+++ b/db/migrate/2021-06-27-1-public-sqlite.sql
@@ -1,0 +1,2 @@
+update sites set settings = json_set(settings, '$.public', 'public')  where json_extract(settings, '$.public') = 1;
+update sites set settings = json_set(settings, '$.public', 'private') where json_extract(settings, '$.public') = 0;

--- a/go.mod
+++ b/go.mod
@@ -40,7 +40,7 @@ require (
 	zgo.at/zstd v0.0.0-20210628014301-6fe5ffd0474c
 	zgo.at/zstripe v1.1.1-0.20210407063143-62ac9deebc08
 	zgo.at/ztpl v0.0.0-20210522104216-89fb2373a16b
-	zgo.at/zvalidate v0.0.0-20210415003959-d3c7c37d3304
+	zgo.at/zvalidate v0.0.0-20210627041111-7942ce72d87f
 )
 
 // "Fork" of go-sqlite3 which: is updated to SQLite 3.35.4 and removes the

--- a/go.sum
+++ b/go.sum
@@ -153,5 +153,5 @@ zgo.at/zstripe v1.1.1-0.20210407063143-62ac9deebc08/go.mod h1:bIBaT9rsnc+uWMSf+6
 zgo.at/ztpl v0.0.0-20210521121045-35d7df223188/go.mod h1:acpuolnKwBftb7ISLZGKWm10YFqJ9a9bP3hClIoDglc=
 zgo.at/ztpl v0.0.0-20210522104216-89fb2373a16b h1:P8qQPjUBogY0NCiinLnGRvK+CtFt2l7BjCVnWqdHAUg=
 zgo.at/ztpl v0.0.0-20210522104216-89fb2373a16b/go.mod h1:mhjSF7+pfwMjNhDgmw9Ywr1CixzeVWuvMjF7gLJT8Uw=
-zgo.at/zvalidate v0.0.0-20210415003959-d3c7c37d3304 h1:JlRlz8BP+SgQKtp2bpyrJmvDR76rPnBo2h4Z1wGEvz4=
-zgo.at/zvalidate v0.0.0-20210415003959-d3c7c37d3304/go.mod h1:WiF1dChwUrGhTRTPCe96HbJSkj9ztxARSgP+tEWAdJ0=
+zgo.at/zvalidate v0.0.0-20210627041111-7942ce72d87f h1:gxnihBTZQ8W6tJCvlJCakO2ekiaeI3Dm6UEAzln4qAo=
+zgo.at/zvalidate v0.0.0-20210627041111-7942ce72d87f/go.mod h1:WiF1dChwUrGhTRTPCe96HbJSkj9ztxARSgP+tEWAdJ0=

--- a/handlers/dashboard.go
+++ b/handlers/dashboard.go
@@ -35,7 +35,7 @@ func (h backend) dashboard(w http.ResponseWriter, r *http.Request) error {
 
 	// Cache much more aggressively for public displays. Don't care so much if
 	// it's outdated by an hour.
-	if site.Settings.Public && User(r.Context()).ID == 0 {
+	if site.Settings.IsPublic() && User(r.Context()).ID == 0 {
 		w.Header().Set("Cache-Control", "public,max-age=3600")
 		w.Header().Set("Vary", "Cookie")
 	}

--- a/public/backend.css
+++ b/public/backend.css
@@ -303,6 +303,10 @@ tr.target .chart-left { display: block; }
 	.tab-nav a { line-height: 2.5em; }
 }
 
+/*** Settings page
+ *******************/
+#page-settings-main #secret { display: none; margin-left: 1em; padding-left: 1em; border-left: 1px solid #aaa; }
+
 /*** Widget settings
  *******************/
 .widget                 { position: relative; margin-bottom: .5em; padding-left: 2em; border-top: 1px solid #e6e6e6; box-shadow: 2px 2px 2px rgba(0,0,0,.2); }

--- a/public/backend.js
+++ b/public/backend.js
@@ -153,6 +153,25 @@
 				},
 			})
 		})
+
+		// Generate random token.
+		$('#rnd-secret').on('click', function(e) {
+			e.preventDefault()
+			$('#settings-secret').val(Array.from(window.crypto.getRandomValues(new Uint8Array(20)), (c) => c.toString(36)).join(''))
+			$('#settings-secret').trigger('change')
+		})
+
+		// Show secret token.
+		$('#settings-public').on('change', function(e) {
+			$('#secret').css('display', $(this).val() === 'secret' ? 'block' : 'none')
+			if ($('#settings-secret').val() === '')
+				$('#rnd-secret').trigger('click')
+		}).trigger('change')
+
+		// Update redirect link.
+		$('#settings-secret').on('change', function(e) {
+			$('#secret-url').val(`${location.protocol}//${location.host}?access-token=${this.value}`)
+		}).trigger('change')
 	}
 
 	var page_user_pref = function() {

--- a/tpl/_backend_top.gohtml
+++ b/tpl/_backend_top.gohtml
@@ -62,7 +62,7 @@
 					<button class="link">{{.T "top-nav/sign-out|Sign out"}}</button>
 				</form>
 			</div>
-		{{else if .Site.Settings.Public}}
+		{{else if .Site.Settings.IsPublic}}
 			<div style="margin-left: .3em;">
 				{{if .Site.LinkDomain -}}
 					{{.T "top-nav/public-link|Analytics for %[link %(domain)]." (map

--- a/tpl/settings_main.gohtml
+++ b/tpl/settings_main.gohtml
@@ -22,14 +22,28 @@
 					Normally administrators can’t “log in” to your site, but if this is enabled they can. You may be asked to enable this for support requests.`}}</span>
 			{{end}}
 
-			<label>{{checkbox .Site.Settings.Public "settings.public"}}
-				{{.T "label/make-statistics-viewable|Make statistics publicly viewable"}}</label>
-			<span>{{.T "p/all-access-statistics|Anyone can view the statistics without logging in."}}</span>
-
 			<label>{{checkbox .Site.Settings.AllowCounter "settings.allow_counter"}}
 				{{.T "label/allow-visitor-counts|Allow adding visitor counts on your website"}}</label>
 			<span>{{.T "help/allow-visitor-counts|See %[link the documentation] for details on how to use."
 				(tag "a" `href="/code/visitor-counter"`)}}</span>
+
+			<label for="settings.public">{{.T "label/dashboard-public|Dashboard viewable by"}}</label>
+			<select name="settings.public" id="settings-public">
+				<option {{option_value .Site.Settings.Public "private"}}>{{.T "label/public-private|Only logged in users"}}</option>
+				<option {{option_value .Site.Settings.Public "secret"}}>{{.T "label/public-private|Logged in users or with secret token"}}</option>
+				<option {{option_value .Site.Settings.Public "public"}}>{{.T "label/public-private|Anyone"}}</option>
+			</select>
+			<span>{{.T "help/public|Control who can view the dashboard."}}</span>
+
+			<div id="secret">
+				<label for="settings-secret">{{.T "label/secret-token|Secret token"}}</label>
+				<input type="text" name="settings.secret" id="settings-secret" value="{{.Site.Settings.Secret}}">
+				<a href="#" id="rnd-secret">{{.T "link/generate-random|Generate random secret."}}</a><br>
+				{{validate "site.settings.secret" .Validate}}
+
+				{{.T "label/secret-access|Secret access URL:"}}
+				<input type="text" id="secret-url" style="width:100%" readonly>
+			</div>
 		</fieldset>
 
 		<fieldset id="section-domain">


### PR DESCRIPTION
I don't really like how I need to pass the token to all the endpoints,
and the token remains in the URL.

Better would be to:

    if valid_token:
	set_session_cookie(token)
	redirect(url_without_token0

Also need to improve form a bit: only show "secret" when this option is
selected, and add option to generate a random value.

Fixes #496