### PR TITLE
Set bottom, width, and height on counter image

### DIFF
--- a/public/count.js
+++ b/public/count.js
@@ -153,6 +153,9 @@
 		var img = document.createElement('img')
 		img.src = url
 		img.style.position = 'absolute'  // Affect layout less.
+		img.style.bottom = '0px'
+		img.style.width = '1px'
+		img.style.height = '1px'
 		img.setAttribute('alt', '')
 		img.setAttribute('aria-hidden', 'true')
 

--- a/public/count.js
+++ b/public/count.js
@@ -156,6 +156,7 @@
 		img.style.bottom = '0px'
 		img.style.width = '1px'
 		img.style.height = '1px'
+		img.loading = 'eager'
 		img.setAttribute('alt', '')
 		img.setAttribute('aria-hidden', 'true')
 


### PR DESCRIPTION
In this example:

	<style>
	    .body    { overflow: auto; height: 100px; position: relative; }
	    .content { height: 100%; background: red; }
	    img      { position: absolute; }
	</style>
	<div class='body'>
	    <div class='content'></div>
	    <img src='/img.png'>
	</div>

The .body is too high: the image gets rendered as absolute and added to
the bottom; because of the overflow: auto and fixed height this will
increase the size and show an unintentional scrollbar

Potential solutions:

- Add width/height of 0
- Set position: bottom

Both work, and I'm not sure if there's really any reason to prefer one
over the other. I choose position: bottom because I wouldn't be
surprised if browsers would optimize that out and it won't load at all.

A second issue that in this case the image gets replaced by a ~30×30px
placeholder image because it doesn't load. Adding a width/height of `1`
to minimize that seems like a good idea in any case.

Fixes #504